### PR TITLE
feat: Typeform-style horizontal PageView for chat flow

### DIFF
--- a/lib/chat/bloc/chat_bloc.dart
+++ b/lib/chat/bloc/chat_bloc.dart
@@ -20,7 +20,8 @@ class ChatBloc extends Bloc<ChatEvent, ChatState> {
       super(const ChatState()) {
     on<ChatStarted>(_onStarted);
     on<ChatMessageSent>(_onMessageSent);
-    on<ChatConversationUpdated>(_onConversationUpdated);
+    on<ChatNewPageStarted>(_onNewPageStarted);
+    on<ChatContentReceived>(_onContentReceived);
     on<ChatLoading>(_onLoading);
     on<ChatErrorOccurred>(_onErrorOccurred);
   }
@@ -30,7 +31,6 @@ class ChatBloc extends Bloc<ChatEvent, ChatState> {
   FirebaseAIChatModel? _chatModel;
   StreamSubscription<ConversationEvent>? _eventSubscription;
   late final List<ChatMessage> _history = [];
-  late final List<DisplayMessage> _displayMessages = [];
   late String _systemPrompt;
 
   Future<void> _onStarted(
@@ -69,15 +69,17 @@ class ChatBloc extends Bloc<ChatEvent, ChatState> {
     _eventSubscription = _conversation!.events.listen((event) {
       if (isClosed) return;
       switch (event) {
+        case ConversationWaiting():
+          add(const ChatNewPageStarted());
+          add(const ChatLoading(isLoading: true));
         case ConversationContentReceived(:final text):
-          _addDisplayMessage(AiTextDisplayMessage(text));
+          add(ChatContentReceived(AiTextDisplayMessage(text)));
         case ConversationSurfaceAdded(:final surfaceId):
-          _addDisplayMessage(AiSurfaceDisplayMessage(surfaceId));
+          add(ChatContentReceived(AiSurfaceDisplayMessage(surfaceId)));
         case ConversationError(:final error):
           add(ChatErrorOccurred(error.toString()));
-        case ConversationWaiting():
-          add(const ChatLoading(isLoading: true));
         case _:
+          // ConversationComponentsUpdated: Surface widget auto-rebuilds.
           break;
       }
     });
@@ -98,20 +100,12 @@ class ChatBloc extends Bloc<ChatEvent, ChatState> {
       focusOptions: event.focusOptions,
       customOption: event.customOption,
     );
-    _addDisplayMessage(UserDisplayMessage(initialMessage));
     await _conversation!.sendRequest(ChatMessage.user(initialMessage));
   }
 
   void _onStateChanged() {
     if (!isClosed) {
       add(ChatLoading(isLoading: _conversation!.state.value.isWaiting));
-    }
-  }
-
-  void _addDisplayMessage(DisplayMessage message) {
-    if (!isClosed) {
-      _displayMessages.add(message);
-      add(ChatConversationUpdated(List.of(_displayMessages)));
     }
   }
 
@@ -138,11 +132,27 @@ class ChatBloc extends Bloc<ChatEvent, ChatState> {
     _history.add(ChatMessage.model(buffer.toString()));
   }
 
-  void _onConversationUpdated(
-    ChatConversationUpdated event,
+  void _onNewPageStarted(
+    ChatNewPageStarted event,
     Emitter<ChatState> emit,
   ) {
-    emit(state.copyWith(messages: event.messages));
+    final pages = [...state.pages, <DisplayMessage>[]];
+    emit(state.copyWith(pages: pages, currentPageIndex: pages.length - 1));
+  }
+
+  void _onContentReceived(
+    ChatContentReceived event,
+    Emitter<ChatState> emit,
+  ) {
+    if (state.pages.isEmpty) return;
+    final pages = [
+      for (var i = 0; i < state.pages.length; i++)
+        if (i == state.currentPageIndex)
+          [...state.pages[i], event.message]
+        else
+          state.pages[i],
+    ];
+    emit(state.copyWith(pages: pages));
   }
 
   void _onLoading(
@@ -156,7 +166,6 @@ class ChatBloc extends Bloc<ChatEvent, ChatState> {
     ChatMessageSent event,
     Emitter<ChatState> emit,
   ) async {
-    _addDisplayMessage(UserDisplayMessage(event.text));
     await _conversation?.sendRequest(ChatMessage.user(event.text));
   }
 

--- a/lib/chat/bloc/chat_event.dart
+++ b/lib/chat/bloc/chat_event.dart
@@ -27,11 +27,16 @@ final class ChatMessageSent extends ChatEvent {
   final String text;
 }
 
-/// Conversation messages changed
-final class ChatConversationUpdated extends ChatEvent {
-  const ChatConversationUpdated(this.messages);
+/// A new AI response turn has started — create a new page.
+final class ChatNewPageStarted extends ChatEvent {
+  const ChatNewPageStarted();
+}
 
-  final List<DisplayMessage> messages;
+/// A display message was added to the current page.
+final class ChatContentReceived extends ChatEvent {
+  const ChatContentReceived(this.message);
+
+  final DisplayMessage message;
 }
 
 /// Loading state when LLM is processing a request

--- a/lib/chat/bloc/chat_state.dart
+++ b/lib/chat/bloc/chat_state.dart
@@ -33,28 +33,37 @@ final class ChatState {
   /// {@macro advisor_state}
   const ChatState({
     this.status = ChatStatus.initial,
-    this.messages = const [],
+    this.pages = const [],
+    this.currentPageIndex = 0,
     this.isLoading = false,
     this.host,
     this.error,
   });
 
   final ChatStatus status;
-  final List<DisplayMessage> messages;
+
+  /// Each page is a list of display messages shown on one full-screen step.
+  final List<List<DisplayMessage>> pages;
+
+  /// The index of the page currently being built by the AI.
+  final int currentPageIndex;
+
   final bool isLoading;
   final SurfaceHost? host;
   final String? error;
 
   ChatState copyWith({
     ChatStatus? status,
-    List<DisplayMessage>? messages,
+    List<List<DisplayMessage>>? pages,
+    int? currentPageIndex,
     bool? isLoading,
     SurfaceHost? host,
     String? error,
   }) {
     return ChatState(
       status: status ?? this.status,
-      messages: messages ?? this.messages,
+      pages: pages ?? this.pages,
+      currentPageIndex: currentPageIndex ?? this.currentPageIndex,
       isLoading: isLoading ?? this.isLoading,
       host: host ?? this.host,
       error: error ?? this.error,

--- a/lib/chat/view/chat_view.dart
+++ b/lib/chat/view/chat_view.dart
@@ -1,12 +1,28 @@
+import 'dart:async';
+
 import 'package:finance_app/app/presentation/spacing.dart';
 import 'package:finance_app/chat/bloc/bloc.dart';
 import 'package:finance_app/chat/chat.dart';
 import 'package:finance_app/l10n/l10n.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:genui/genui.dart';
 
-class ChatView extends StatelessWidget {
+class ChatView extends StatefulWidget {
   const ChatView({super.key});
+
+  @override
+  State<ChatView> createState() => _ChatViewState();
+}
+
+class _ChatViewState extends State<ChatView> {
+  final _pageController = PageController();
+
+  @override
+  void dispose() {
+    _pageController.dispose();
+    super.dispose();
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -15,56 +31,85 @@ class ChatView extends StatelessWidget {
 
     return Scaffold(
       appBar: AppBar(title: Text(l10n.chatAppBarTitle)),
-      body: Column(
-        children: [
-          Expanded(
-            child: BlocBuilder<ChatBloc, ChatState>(
-              buildWhen: (previous, current) =>
-                  previous.messages != current.messages,
-              builder: (context, state) {
-                if (state.messages.isEmpty) {
-                  return Center(
-                    child: Text(l10n.startChattingLabel),
-                  );
-                }
-                return ListView.builder(
-                  reverse: true,
-                  padding: const EdgeInsets.symmetric(vertical: Spacing.xs),
-                  itemCount: state.messages.length,
-                  itemBuilder: (context, index) {
-                    final message =
-                        state.messages[state.messages.length - 1 - index];
-                    return ChatMessageBubble(
-                      message: message,
-                      host: state.host!,
-                    );
+      body: BlocConsumer<ChatBloc, ChatState>(
+        listenWhen: (previous, current) =>
+            previous.currentPageIndex != current.currentPageIndex,
+        listener: (context, state) {
+          if (_pageController.hasClients && state.pages.isNotEmpty) {
+            unawaited(
+              _pageController.animateToPage(
+                state.currentPageIndex,
+                duration: const Duration(milliseconds: 400),
+                curve: Curves.easeInOut,
+              ),
+            );
+          }
+        },
+        buildWhen: (previous, current) =>
+            previous.pages != current.pages ||
+            previous.isLoading != current.isLoading ||
+            previous.status != current.status,
+        builder: (context, state) {
+          return Column(
+            children: [
+              Expanded(
+                child: state.pages.isEmpty
+                    ? Center(child: Text(l10n.startChattingLabel))
+                    : PageView.builder(
+                        controller: _pageController,
+                        itemCount: state.pages.length,
+                        itemBuilder: (context, pageIndex) {
+                          final messages = state.pages[pageIndex];
+                          return _ChatPage(
+                            messages: messages,
+                            host: state.host!,
+                            isLoading:
+                                state.isLoading &&
+                                pageIndex == state.currentPageIndex,
+                          );
+                        },
+                      ),
+              ),
+              if (state.status == ChatStatus.active)
+                ChatInputBar(
+                  enabled: !state.isLoading,
+                  onSend: (text) {
+                    chatBloc.add(ChatMessageSent(text));
                   },
-                );
-              },
+                ),
+            ],
+          );
+        },
+      ),
+    );
+  }
+}
+
+class _ChatPage extends StatelessWidget {
+  const _ChatPage({
+    required this.messages,
+    required this.host,
+    required this.isLoading,
+  });
+
+  final List<DisplayMessage> messages;
+  final SurfaceHost host;
+  final bool isLoading;
+
+  @override
+  Widget build(BuildContext context) {
+    return SingleChildScrollView(
+      padding: const EdgeInsets.symmetric(vertical: Spacing.xs),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          for (final message in messages)
+            ChatMessageBubble(message: message, host: host),
+          if (isLoading)
+            const Padding(
+              padding: EdgeInsets.all(Spacing.md),
+              child: Center(child: CircularProgressIndicator()),
             ),
-          ),
-          BlocBuilder<ChatBloc, ChatState>(
-            buildWhen: (previous, current) =>
-                previous.isLoading != current.isLoading ||
-                previous.status != current.status,
-            builder: (context, state) {
-              if (state.isLoading) {
-                return const Padding(
-                  padding: EdgeInsets.symmetric(
-                    horizontal: Spacing.md,
-                    vertical: Spacing.md,
-                  ),
-                  child: CircularProgressIndicator(),
-                );
-              }
-              return ChatInputBar(
-                enabled: state.status == ChatStatus.active && !state.isLoading,
-                onSend: (text) {
-                  chatBloc.add(ChatMessageSent(text));
-                },
-              );
-            },
-          ),
         ],
       ),
     );

--- a/test/chat/bloc/chat_bloc_test.dart
+++ b/test/chat/bloc/chat_bloc_test.dart
@@ -31,7 +31,8 @@ void main() {
     test('has correct defaults', () {
       const state = ChatState();
       expect(state.status, ChatStatus.initial);
-      expect(state.messages, isEmpty);
+      expect(state.pages, isEmpty);
+      expect(state.currentPageIndex, 0);
       expect(state.isLoading, isFalse);
       expect(state.host, isNull);
       expect(state.error, isNull);
@@ -41,12 +42,15 @@ void main() {
       const state = ChatState();
       final updated = state.copyWith(
         status: ChatStatus.error,
-        messages: [const UserDisplayMessage('hi')],
+        pages: [
+          [const UserDisplayMessage('hi')],
+        ],
         isLoading: true,
         error: 'oops',
       );
       expect(updated.status, ChatStatus.error);
-      expect(updated.messages, hasLength(1));
+      expect(updated.pages, hasLength(1));
+      expect(updated.currentPageIndex, 0);
       expect(updated.isLoading, isTrue);
       expect(updated.error, 'oops');
     });
@@ -54,13 +58,16 @@ void main() {
     test('copyWith preserves values when not overridden', () {
       const state = ChatState(
         status: ChatStatus.active,
-        messages: [UserDisplayMessage('hi')],
+        pages: [
+          [UserDisplayMessage('hi')],
+        ],
         isLoading: true,
         error: 'err',
       );
       final copy = state.copyWith();
       expect(copy.status, ChatStatus.active);
-      expect(copy.messages, hasLength(1));
+      expect(copy.pages, hasLength(1));
+      expect(copy.currentPageIndex, 0);
       expect(copy.isLoading, isTrue);
       expect(copy.error, 'err');
     });
@@ -97,10 +104,14 @@ void main() {
       expect(event.text, 'hello');
     });
 
-    test('$ChatConversationUpdated holds messages', () {
-      const msgs = <DisplayMessage>[UserDisplayMessage('a')];
-      const event = ChatConversationUpdated(msgs);
-      expect(event.messages, msgs);
+    test('$ChatNewPageStarted is const constructible', () {
+      const event = ChatNewPageStarted();
+      expect(event, isA<ChatEvent>());
+    });
+
+    test('$ChatContentReceived holds message', () {
+      const event = ChatContentReceived(AiTextDisplayMessage('hi'));
+      expect(event.message, isA<AiTextDisplayMessage>());
     });
 
     test('$ChatLoading holds isLoading', () {
@@ -118,32 +129,46 @@ void main() {
     test('initial state is {$ChatState()}', () {
       final bloc = _buildBloc();
       expect(bloc.state.status, ChatStatus.initial);
-      expect(bloc.state.messages, isEmpty);
+      expect(bloc.state.pages, isEmpty);
       expect(bloc.state.isLoading, isFalse);
       addTearDown(bloc.close);
     });
 
     blocTest<ChatBloc, ChatState>(
-      '$ChatStarted emits loading, then active with host and initial '
-      'message',
+      '$ChatStarted emits loading, then active with host',
       build: _buildBloc,
       act: (bloc) => bloc.add(_chatStarted),
       verify: (bloc) {
         expect(bloc.state.status, ChatStatus.active);
         expect(bloc.state.host, isNotNull);
-        expect(bloc.state.messages, isNotEmpty);
-        expect(bloc.state.messages.first, isA<UserDisplayMessage>());
       },
     );
 
     blocTest<ChatBloc, ChatState>(
-      '$ChatConversationUpdated emits state with new messages',
+      '$ChatNewPageStarted adds an empty page',
       build: _buildBloc,
-      act: (bloc) => bloc.add(
-        const ChatConversationUpdated([UserDisplayMessage('msg')]),
-      ),
+      act: (bloc) => bloc.add(const ChatNewPageStarted()),
       expect: () => [
-        isA<ChatState>().having((s) => s.messages, 'messages', hasLength(1)),
+        isA<ChatState>()
+            .having((s) => s.pages, 'pages', hasLength(1))
+            .having((s) => s.currentPageIndex, 'currentPageIndex', 0),
+      ],
+    );
+
+    blocTest<ChatBloc, ChatState>(
+      '$ChatContentReceived appends message to current page',
+      build: _buildBloc,
+      seed: () => const ChatState(
+        pages: [[]],
+      ),
+      act: (bloc) =>
+          bloc.add(const ChatContentReceived(AiTextDisplayMessage('hi'))),
+      expect: () => [
+        isA<ChatState>().having(
+          (s) => s.pages.first,
+          'first page',
+          hasLength(1),
+        ),
       ],
     );
 

--- a/test/chat/view/chat_view_test.dart
+++ b/test/chat/view/chat_view_test.dart
@@ -41,7 +41,7 @@ void main() {
   });
 
   group(ChatView, () {
-    testWidgets('shows empty-state label when messages are empty', (
+    testWidgets('shows empty-state label when pages are empty', (
       tester,
     ) async {
       await tester.pumpChatView(bloc);
@@ -58,32 +58,24 @@ void main() {
       await tester.pumpChatView(bloc);
 
       expect(find.byType(ChatInputBar), findsOneWidget);
-      expect(find.byType(CircularProgressIndicator), findsNothing);
     });
 
-    testWidgets('shows $CircularProgressIndicator when loading', (
+    testWidgets('renders message bubbles in PageView when pages exist', (
       tester,
     ) async {
-      when(() => bloc.state).thenReturn(
-        const ChatState(status: ChatStatus.active, isLoading: true),
-      );
-      await tester.pumpChatView(bloc);
-
-      expect(find.byType(CircularProgressIndicator), findsOneWidget);
-      expect(find.byType(ChatInputBar), findsNothing);
-    });
-
-    testWidgets('renders message bubbles when messages exist', (tester) async {
       final host = _MockSurfaceHost();
       when(() => bloc.state).thenReturn(
         ChatState(
           status: ChatStatus.active,
-          messages: const [UserDisplayMessage('Hello')],
+          pages: const [
+            [AiTextDisplayMessage('Hello')],
+          ],
           host: host,
         ),
       );
       await tester.pumpChatView(bloc);
 
+      expect(find.byType(PageView), findsOneWidget);
       expect(find.byType(ChatMessageBubble), findsOneWidget);
       expect(
         find.text('Send a message to get started!'),
@@ -114,7 +106,7 @@ void main() {
       expect((captured.first as ChatMessageSent).text, 'hi');
     });
 
-    testWidgets('$ChatInputBar is disabled when status is not active', (
+    testWidgets('$ChatInputBar is not shown when status is not active', (
       tester,
     ) async {
       when(() => bloc.state).thenReturn(
@@ -122,22 +114,36 @@ void main() {
       );
       await tester.pumpChatView(bloc);
 
-      final inputBar = tester.widget<ChatInputBar>(
-        find.byType(ChatInputBar),
-      );
-      expect(inputBar.enabled, isFalse);
+      expect(find.byType(ChatInputBar), findsNothing);
     });
 
-    testWidgets('messages buildWhen triggers rebuild on message change', (
+    testWidgets('shows loading indicator on current page when loading', (
       tester,
     ) async {
+      final host = _MockSurfaceHost();
+      when(() => bloc.state).thenReturn(
+        ChatState(
+          status: ChatStatus.active,
+          pages: const [[]],
+          isLoading: true,
+          host: host,
+        ),
+      );
+      await tester.pumpChatView(bloc);
+
+      expect(find.byType(CircularProgressIndicator), findsOneWidget);
+    });
+
+    testWidgets('rebuilds when pages change', (tester) async {
       final host = _MockSurfaceHost();
       whenListen(
         bloc,
         Stream.fromIterable([
           ChatState(
             status: ChatStatus.active,
-            messages: const [UserDisplayMessage('Hello')],
+            pages: const [
+              [AiTextDisplayMessage('Hello')],
+            ],
             host: host,
           ),
         ]),
@@ -148,23 +154,6 @@ void main() {
       await tester.pump();
 
       expect(find.byType(ChatMessageBubble), findsOneWidget);
-    });
-
-    testWidgets('bottom buildWhen triggers rebuild on loading change', (
-      tester,
-    ) async {
-      whenListen(
-        bloc,
-        Stream.fromIterable([
-          const ChatState(status: ChatStatus.active, isLoading: true),
-        ]),
-        initialState: const ChatState(status: ChatStatus.active),
-      );
-
-      await tester.pumpChatView(bloc);
-      await tester.pump();
-
-      expect(find.byType(CircularProgressIndicator), findsOneWidget);
     });
   });
 }


### PR DESCRIPTION
## Description

Replaces the vertical scrolling chat `ListView` with a horizontal `PageView` to create a Typeform-style experience matching the designer's vision. Each AI response turn becomes a full-screen page that users swipe through horizontally, with each page individually scrollable for long content.

**Key behavior:**
- **New content** (new AI response turn) → creates a new page, animates forward
- **Surface updates** (e.g. recalculated metrics) → stays on the current page, `Surface` widget auto-rebuilds via GenUI's reactive `ValueListenableBuilder`

**Changes:**
- `ChatState`: Replaced flat `List<DisplayMessage>` with `List<List<DisplayMessage>>` pages + `currentPageIndex`
- `ChatBloc`: `ConversationWaiting` starts a new page; content/surfaces append to current page; `ConversationComponentsUpdated` is a no-op (auto-handled)
- `ChatView`: `PageView.builder` with `BlocConsumer` for animated page transitions
- Tests updated for the new state shape

Resolves #163

## Preview

Design reference: [Figma](https://www.figma.com/design/9JqrfXMFsOrByfbLzwhmNp/Google-Cloud-Next?node-id=2056-6058)

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [x] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
- [ ] 🧪 Test

## Readiness Checklist

- [x] Linked to a Story issue (`Resolves #...`)
- [x] Story goals are addressed
- [ ] Acceptance criteria are met (or clearly called out as partial)
- [ ] Designs are implemented as approved, or design deviations are documented
- [ ] Analytics requirements are implemented, or marked as not applicable
- [x] Tests were added/updated, or justification provided if not needed
- [ ] Documentation was updated when needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)