### PR TITLE
refactor: use AppButton in transaction list

### DIFF
--- a/lib/advisor/catalog/finance_catalog.dart
+++ b/lib/advisor/catalog/finance_catalog.dart
@@ -63,7 +63,7 @@ Use ProgressBar to show spending categories vs. a fixed budget limit. Set value 
 
 Use the SparklineCard widget to display a financial category with its amount and a trend sparkline. Set trend to "positive" (green) for growing values, "negative" (red) for declining values, or "stable" (blue) for flat trends.
 
-Use the TransactionList widget to display a list of recent transactions. Each item shows a title (merchant name), description (category), and formatted amount.
+Use the TransactionList widget to display a list of recent transactions. Each item shows a title (merchant name), description (category), and formatted amount. Optionally include an "action" on each item to show a View button — when tapped, it dispatches the specified event with the item's data as context.
 ''';
 
 /// Builds the full catalog of financial widgets for GenUI.

--- a/lib/advisor/catalog/items/transaction_list.dart
+++ b/lib/advisor/catalog/items/transaction_list.dart
@@ -17,6 +17,10 @@ final _schema = S.object(
           'amount': A2uiSchemas.stringReference(
             description: r'Formatted amount string (e.g. "$450").',
           ),
+          'action': A2uiSchemas.action(
+            description:
+                'Optional action dispatched when the View button is tapped.',
+          ),
         },
         required: ['title', 'description', 'amount'],
       ),
@@ -34,10 +38,30 @@ final transactionListItem = CatalogItem(
     final rawItems = json['items']! as List;
 
     final items = rawItems.cast<Map<String, Object?>>().map((item) {
+      final action = item['action'] as Map<String, Object?>?;
+
       return TransactionListItem(
         title: _resolveString(item['title']),
         description: _resolveString(item['description']),
         amount: _resolveString(item['amount']),
+        onViewDetails: action == null
+            ? null
+            : () {
+                if (action case {'event': final Map<String, Object?> event}) {
+                  ctx.dispatchEvent(
+                    UserActionEvent(
+                      name: event['name']! as String,
+                      sourceComponentId: ctx.id,
+                      context: {
+                        ...event['context'] as Map<String, Object?>? ?? {},
+                        'title': _resolveString(item['title']),
+                        'description': _resolveString(item['description']),
+                        'amount': _resolveString(item['amount']),
+                      },
+                    ),
+                  );
+                }
+              },
       );
     }).toList();
 

--- a/lib/app/presentation/widgets/transaction_list.dart
+++ b/lib/app/presentation/widgets/transaction_list.dart
@@ -116,25 +116,10 @@ class _TransactionListRow extends StatelessWidget {
             ),
           ),
           if (item.onViewDetails != null) ...[
-            // TODO(juanRodriguez17): Replace with custom button widget
-            //when gets merged
-            FilledButton(
+            AppButton(
+              label: l10n.viewLabel,
+              size: AppButtonSize.small,
               onPressed: item.onViewDetails,
-              style: FilledButton.styleFrom(
-                backgroundColor: colors?.primary,
-                shape: RoundedRectangleBorder(
-                  borderRadius: BorderRadius.circular(100),
-                ),
-                padding: const EdgeInsets.symmetric(
-                  horizontal: Spacing.sm,
-                ),
-              ),
-              child: Text(
-                l10n.viewLabel,
-                style: textTheme.labelLarge?.copyWith(
-                  color: colors?.onInverseSurface,
-                ),
-              ),
             ),
           ],
         ],

--- a/test/advisor/catalog/items/transaction_list_test.dart
+++ b/test/advisor/catalog/items/transaction_list_test.dart
@@ -1,5 +1,5 @@
 import 'package:finance_app/advisor/catalog/items/transaction_list.dart';
-import 'package:finance_app/app/presentation/widgets/transaction_list.dart';
+import 'package:finance_app/app/presentation.dart';
 import 'package:finance_app/l10n/l10n.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -29,14 +29,15 @@ Map<String, Object?> _data({
 
 CatalogItemContext _context(
   BuildContext context,
-  Map<String, Object?> data,
-) {
+  Map<String, Object?> data, {
+  DispatchEventCallback? dispatchEvent,
+}) {
   return CatalogItemContext(
     data: data,
     id: 'test',
     type: 'TransactionList',
     buildChild: (id, [dataContext]) => const SizedBox.shrink(),
-    dispatchEvent: (_) {},
+    dispatchEvent: dispatchEvent ?? (_) {},
     buildContext: context,
     dataContext: DataContext(_MockDataModel(), DataPath.root),
     getComponent: (_) => null,
@@ -48,8 +49,9 @@ CatalogItemContext _context(
 
 Future<void> _pump(
   WidgetTester tester,
-  Map<String, Object?> data,
-) async {
+  Map<String, Object?> data, {
+  DispatchEventCallback? dispatchEvent,
+}) async {
   await tester.pumpWidget(
     MaterialApp(
       localizationsDelegates: AppLocalizations.localizationsDelegates,
@@ -58,7 +60,7 @@ Future<void> _pump(
         body: SingleChildScrollView(
           child: Builder(
             builder: (context) => transactionListItem.widgetBuilder(
-              _context(context, data),
+              _context(context, data, dispatchEvent: dispatchEvent),
             ),
           ),
         ),
@@ -114,6 +116,69 @@ void main() {
         expect(find.text('Gym'), findsOneWidget);
         expect(find.text('Fitness'), findsOneWidget);
         expect(find.text(r'$50'), findsOneWidget);
+      });
+
+      testWidgets('shows AppButton when item has action', (tester) async {
+        await _pump(
+          tester,
+          _data(
+            items: [
+              {
+                'title': 'Nobu Restaurant',
+                'description': 'Dining',
+                'amount': r'$450',
+                'action': {
+                  'event': {
+                    'name': 'view_transaction',
+                    'context': <String, Object?>{},
+                  },
+                },
+              },
+            ],
+          ),
+        );
+
+        expect(find.byType(AppButton), findsOneWidget);
+      });
+
+      testWidgets('dispatches event when View button is tapped', (
+        tester,
+      ) async {
+        UserActionEvent? dispatched;
+
+        await _pump(
+          tester,
+          _data(
+            items: [
+              {
+                'title': 'Nobu Restaurant',
+                'description': 'Dining',
+                'amount': r'$450',
+                'action': {
+                  'event': {
+                    'name': 'view_transaction',
+                    'context': <String, Object?>{},
+                  },
+                },
+              },
+            ],
+          ),
+          dispatchEvent: (event) => dispatched = event as UserActionEvent,
+        );
+
+        await tester.tap(find.byType(AppButton));
+
+        expect(dispatched, isNotNull);
+        expect(dispatched!.name, 'view_transaction');
+        expect(dispatched!.context['title'], 'Nobu Restaurant');
+      });
+
+      testWidgets('does not show AppButton when item has no action', (
+        tester,
+      ) async {
+        await _pump(tester, _data());
+
+        expect(find.byType(AppButton), findsNothing);
       });
     });
   });

--- a/test/app/presentation/widgets/transaction_list_test.dart
+++ b/test/app/presentation/widgets/transaction_list_test.dart
@@ -115,7 +115,7 @@ void main() {
       );
 
       expect(find.text('View'), findsOneWidget);
-      expect(find.byType(FilledButton), findsOneWidget);
+      expect(find.byType(AppButton), findsOneWidget);
     });
 
     testWidgets('does not show View button when onViewDetails is null', (
@@ -124,7 +124,7 @@ void main() {
       await _pumpList(tester);
 
       expect(find.text('View'), findsNothing);
-      expect(find.byType(FilledButton), findsNothing);
+      expect(find.byType(AppButton), findsNothing);
     });
 
     testWidgets('tapping View button triggers callback', (tester) async {


### PR DESCRIPTION
## Description

Replace with custom button widget using FilledButton right now, should use AppButton.

Resolves #178

## Preview

<!--- Add screenshots or videos of your change -->

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [x] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
- [ ] 🧪 Test

## Readiness Checklist

<!--- Put an `x` in all the boxes that apply: -->

- [x] Linked to a Story issue (`Resolves #...`)
- [x] Story goals are addressed
- [x] Acceptance criteria are met (or clearly called out as partial)
- [x] Designs are implemented as approved, or design deviations are documented
- [ ] Analytics requirements are implemented, or marked as not applicable
- [x] Tests were added/updated, or justification provided if not needed
- [ ] Documentation was updated when needed
