### PR TITLE
fix: Responsive `IntroMobileView` widget

### DIFF
--- a/lib/onboarding/intro/view/intro_mobile_view.dart
+++ b/lib/onboarding/intro/view/intro_mobile_view.dart
@@ -20,18 +20,14 @@ class IntroMobileView extends StatelessWidget {
     colors: [Color(0xFF93A0F5), Color(0xFFBBB7F9)],
   );
 
-  static const _titleStyle = TextStyle(
-    fontFamily: 'Poppins',
-    color: Colors.white,
-    fontSize: 48,
-    fontWeight: FontWeight.w700,
-    height: 1,
-    letterSpacing: -2,
-  );
+  static TextStyle _getTitleStyle({Color? color}) =>
+      AppTextStyles.displayLargeDesktop.copyWith(color: color);
 
   @override
   Widget build(BuildContext context) {
     final l10n = context.l10n;
+    final colors = Theme.of(context).extension<AppColors>();
+
     return Scaffold(
       backgroundColor: _backgroundColor,
       body: Stack(
@@ -117,16 +113,25 @@ class IntroMobileView extends StatelessWidget {
                 Row(
                   mainAxisSize: MainAxisSize.min,
                   children: [
-                    Text(l10n.introTitlePrefix, style: _titleStyle),
+                    Text(
+                      l10n.introTitlePrefix,
+                      style: _getTitleStyle(color: colors?.onPrimary),
+                    ),
                     ShaderMask(
                       shaderCallback: (bounds) => _vgvGradient.createShader(
                         Rect.fromLTWH(0, 0, bounds.width, bounds.height),
                       ),
-                      child: const Row(
+                      child: Row(
                         mainAxisSize: MainAxisSize.min,
                         children: [
-                          Text('x ', style: _titleStyle),
-                          Text('VGV', style: _titleStyle),
+                          Text(
+                            'x ',
+                            style: _getTitleStyle(color: colors?.onPrimary),
+                          ),
+                          Text(
+                            'VGV',
+                            style: _getTitleStyle(color: colors?.onPrimary),
+                          ),
                         ],
                       ),
                     ),


### PR DESCRIPTION
## Description

* Remove `Positioned` widget from the mobile screen in order to adapt it correctly to different screen sizes

Resolves #218 

## Preview

<img width=40% height=40% alt="Screenshot at Mar 24 13-00-33" src="https://github.com/user-attachments/assets/d8abc293-f538-4524-bdb7-5aa82138c672" />

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [X] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
- [ ] 🧪 Test