### PR TITLE
fix: [Deactivated button] [HOLD NOT MERGE]

### DIFF
--- a/lib/simulator/catalog/finance_catalog.dart
+++ b/lib/simulator/catalog/finance_catalog.dart
@@ -60,8 +60,8 @@ CORRECT — button and content in the same item:
   {"title": "Mortgage Pre-approval", "subtitle": "Lock in a rate and confirm your buying power.", "amount": "Required", "child": "view_rates_btn"},
   {"title": "High-Yield Savings Account", "subtitle": "Best for your \$70,000 down payment fund.", "amount": "4.50% APY", "child": "top_picks_btn"}
 ]}},
-{"id": "view_rates_btn", "component": "AppButton", "label": "View Rates", "variant": "outlined", "size": "small"},
-{"id": "top_picks_btn", "component": "AppButton", "label": "Top Picks", "variant": "outlined", "size": "small"}
+{"id": "view_rates_btn", "component": "AppButton", "label": "View Rates", "variant": "outlined", "size": "small", "action": {"event": {"name": "view_rates"}}},
+{"id": "top_picks_btn", "component": "AppButton", "label": "Top Picks", "variant": "outlined", "size": "small", "action": {"event": {"name": "top_picks"}}}
 ```
 
 WRONG — never split a button into its own separate item:

--- a/lib/simulator/catalog/items/app_button_catalog_item.dart
+++ b/lib/simulator/catalog/items/app_button_catalog_item.dart
@@ -93,6 +93,15 @@ class _OneTapAppButton extends StatefulWidget {
 class _OneTapAppButtonState extends State<_OneTapAppButton> {
   bool _tapped = false;
 
+  @override
+  void didUpdateWidget(covariant _OneTapAppButton oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (widget.action != oldWidget.action ||
+        widget.labelValue != oldWidget.labelValue) {
+      _tapped = false;
+    }
+  }
+
   void _onPressed() {
     if (_tapped) return;
     setState(() => _tapped = true);


### PR DESCRIPTION
## Description

* In order to avoid particular cases when our `AppButtonCatalogItem` gets deactivated we added an action to app button sample prompt. And also added a defensive reset of `_tapped` in `didUpdateWidget` as a safety net in case AI doesn't create a new surface per step

Resolves #250 

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [X] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
- [ ] 🧪 Test