### PR TITLE
feat: Add back button navigation to simulator flow

### DIFF
--- a/lib/simulator/bloc/simulator_bloc.dart
+++ b/lib/simulator/bloc/simulator_bloc.dart
@@ -14,6 +14,8 @@ class SimulatorBloc extends Bloc<SimulatorEvent, SimulatorState> {
       super(const SimulatorState()) {
     on<SimulatorStarted>(_onStarted);
     on<SimulatorMessageSent>(_onMessageSent);
+    on<SimulatorBackPressed>(_onBackPressed);
+    on<SimulatorForwardPagesTruncated>(_onForwardPagesTruncated);
     on<SimulatorSurfaceReceived>(_onSurfaceReceived);
     on<SimulatorContentReceived>(_onContentReceived);
     on<SimulatorLoading>(_onLoading);
@@ -57,6 +59,30 @@ class SimulatorBloc extends Bloc<SimulatorEvent, SimulatorState> {
     await _repository.sendMessage(initialMessage);
   }
 
+  void _onBackPressed(
+    SimulatorBackPressed event,
+    Emitter<SimulatorState> emit,
+  ) {
+    if (state.currentPageIndex > 0) {
+      final newIndex = state.currentPageIndex - 1;
+      _repository.currentStep = newIndex;
+      // Keep forward pages alive so the fade-out animation can play.
+      // Buttons are disabled via isNavigatingBack until the animation
+      // completes and SimulatorForwardPagesTruncated removes the pages.
+      emit(
+        state.copyWith(currentPageIndex: newIndex, isNavigatingBack: true),
+      );
+    }
+  }
+
+  void _onForwardPagesTruncated(
+    SimulatorForwardPagesTruncated event,
+    Emitter<SimulatorState> emit,
+  ) {
+    final pages = state.pages.sublist(0, state.currentPageIndex + 1);
+    emit(state.copyWith(pages: pages, isNavigatingBack: false));
+  }
+
   void _onSurfaceReceived(
     SimulatorSurfaceReceived event,
     Emitter<SimulatorState> emit,
@@ -68,6 +94,7 @@ class SimulatorBloc extends Bloc<SimulatorEvent, SimulatorState> {
     );
 
     if (existingPageIndex != -1) {
+      _repository.currentStep = existingPageIndex;
       emit(
         state.copyWith(
           currentPageIndex: existingPageIndex,
@@ -77,16 +104,30 @@ class SimulatorBloc extends Bloc<SimulatorEvent, SimulatorState> {
       );
     } else {
       final message = AiSurfaceDisplayMessage(event.surfaceId);
+
+      // If forward pages still exist (e.g. the back-animation truncation
+      // hasn't fired yet), trim them before appending the new surface.
+      final base = state.currentPageIndex < state.pages.length - 1
+          ? state.pages.sublist(0, state.currentPageIndex + 1)
+          : state.pages;
+
       final pages = [
-        ...state.pages,
+        ...base,
         <DisplayMessage>[message],
       ];
       final newIndex = pages.length - 1;
+      _repository.currentStep = newIndex;
 
       // Defer navigation until loading finishes so the current page
       // stays visible with the thinking animation until content is ready.
       if (state.isLoading) {
-        emit(state.copyWith(pages: pages, pendingPageIndex: newIndex));
+        emit(
+          state.copyWith(
+            pages: pages,
+            pendingPageIndex: newIndex,
+            isNavigatingBack: false,
+          ),
+        );
       } else {
         emit(
           state.copyWith(
@@ -94,6 +135,7 @@ class SimulatorBloc extends Bloc<SimulatorEvent, SimulatorState> {
             currentPageIndex: newIndex,
             pendingPageIndex: clearPendingPageIndex,
             showLoadingOverlay: false,
+            isNavigatingBack: false,
           ),
         );
       }
@@ -151,17 +193,21 @@ class SimulatorBloc extends Bloc<SimulatorEvent, SimulatorState> {
     SimulatorLoading event,
     Emitter<SimulatorState> emit,
   ) {
-    emit(state.copyWith(isLoading: event.isLoading));
+    final withLoading = state.copyWith(isLoading: event.isLoading);
+    emit(withLoading);
 
     // If loading just finished and there's a deferred page, navigate now.
-    if (!event.isLoading && state.hasPendingNavigation) {
-      emit(
-        state.copyWith(
-          currentPageIndex: state.pendingPageIndex,
-          pendingPageIndex: clearPendingPageIndex,
-          showLoadingOverlay: false,
-        ),
-      );
+    if (!event.isLoading && withLoading.hasPendingNavigation) {
+      final pending = withLoading.pendingPageIndex;
+      if (pending != null) {
+        emit(
+          withLoading.copyWith(
+            currentPageIndex: pending,
+            pendingPageIndex: clearPendingPageIndex,
+            showLoadingOverlay: false,
+          ),
+        );
+      }
     }
   }
 

--- a/lib/simulator/bloc/simulator_event.dart
+++ b/lib/simulator/bloc/simulator_event.dart
@@ -48,6 +48,16 @@ final class SimulatorLoading extends SimulatorEvent {
   final bool isLoading;
 }
 
+/// The user pressed the back button to return to the previous step.
+final class SimulatorBackPressed extends SimulatorEvent {
+  const SimulatorBackPressed();
+}
+
+/// The back-navigation animation has finished — remove forward pages.
+final class SimulatorForwardPagesTruncated extends SimulatorEvent {
+  const SimulatorForwardPagesTruncated();
+}
+
 /// Request to show/hide the full-screen loading overlay animation.
 final class SimulatorLoadingOverlayRequested extends SimulatorEvent {
   const SimulatorLoadingOverlayRequested();

--- a/lib/simulator/bloc/simulator_state.dart
+++ b/lib/simulator/bloc/simulator_state.dart
@@ -21,6 +21,7 @@ final class SimulatorState extends Equatable {
     this.pages = const [],
     this.currentPageIndex = 0,
     this.isLoading = false,
+    this.isNavigatingBack = false,
     this.pendingPageIndex,
     this.showLoadingOverlay = false,
     this.error,
@@ -36,6 +37,12 @@ final class SimulatorState extends Equatable {
 
   /// Whether the LLM is currently processing a request.
   final bool isLoading;
+
+  /// True while the back-navigation animation is in progress.
+  ///
+  /// Used to disable buttons so the user cannot tap Continue before the
+  /// forward pages have been truncated.
+  final bool isNavigatingBack;
 
   /// The index of a page whose navigation has been deferred until the LLM
   /// finishes loading. When non-null, the current page stays visible (with its
@@ -67,6 +74,7 @@ final class SimulatorState extends Equatable {
     List<List<DisplayMessage>>? pages,
     int? currentPageIndex,
     bool? isLoading,
+    bool? isNavigatingBack,
     int? pendingPageIndex,
     bool? showLoadingOverlay,
     String? error,
@@ -76,6 +84,7 @@ final class SimulatorState extends Equatable {
       pages: pages ?? this.pages,
       currentPageIndex: currentPageIndex ?? this.currentPageIndex,
       isLoading: isLoading ?? this.isLoading,
+      isNavigatingBack: isNavigatingBack ?? this.isNavigatingBack,
       pendingPageIndex: pendingPageIndex == clearPendingPageIndex
           ? null
           : pendingPageIndex ?? this.pendingPageIndex,

--- a/lib/simulator/catalog/finance_catalog.dart
+++ b/lib/simulator/catalog/finance_catalog.dart
@@ -30,6 +30,7 @@ Use the AppButton widget to present clear calls-to-action, such as navigating to
 - variant: "filled" for primary actions, "outlined" for secondary actions.
 - size: "large" for prominent actions, "small" for inline or less prominent actions.
 - isLoading: Set to true only when an async operation is in progress.
+- For back navigation, use variant "outlined" with the exact action: {"event": {"name": "go_back"}}.
 
 Use the EmojiCard widget to display a set of categorized options or highlights as emoji-labelled cards in a responsive grid.
 

--- a/lib/simulator/catalog/items/app_button_catalog_item.dart
+++ b/lib/simulator/catalog/items/app_button_catalog_item.dart
@@ -95,8 +95,19 @@ class _OneTapAppButton extends StatefulWidget {
 
 class _OneTapAppButtonState extends State<_OneTapAppButton> {
   bool _tapped = false;
+  int? _lastPageIndex;
+  bool _prevBlocBusy = false;
 
   void _onPressed() {
+    // Handle back navigation directly through the bloc — no LLM call needed.
+    final action = widget.action;
+    if (action case {'event': final Map<String, Object?> event}) {
+      if (event['name'] == 'go_back') {
+        context.read<SimulatorBloc>().add(const SimulatorBackPressed());
+        return;
+      }
+    }
+
     if (_tapped) return;
     setState(() => _tapped = true);
 
@@ -105,8 +116,6 @@ class _OneTapAppButtonState extends State<_OneTapAppButton> {
         const SimulatorLoadingOverlayRequested(),
       );
     }
-
-    final action = widget.action;
     if (action case {'event': final Map<String, Object?> event}) {
       final dataModel = widget.dataContext.dataModel
           .getValue<Map<String, Object?>>(DataPath.root);
@@ -127,6 +136,27 @@ class _OneTapAppButtonState extends State<_OneTapAppButton> {
   @override
   Widget build(BuildContext context) {
     final state = context.watch<SimulatorBloc>().state;
+
+    // Re-enable the button when the page index changes (e.g. after back
+    // navigation) so users can tap Continue again on a revisited page.
+    final currentPageIndex = state.currentPageIndex;
+    if (_lastPageIndex != null && _lastPageIndex != currentPageIndex) {
+      _tapped = false;
+    }
+    _lastPageIndex = currentPageIndex;
+
+    final blocBusy = state.isLoading || state.isNavigatingBack;
+    // GenUI may reuse the same surface id for the next step (in-place update).
+    // Then currentPageIndex does not change and the page-index reset above
+    // never clears _tapped. Re-enable when the bloc finishes a busy period.
+    if (_prevBlocBusy && !blocBusy) {
+      _tapped = false;
+    }
+    _prevBlocBusy = blocBusy;
+
+    // Only show the thinking animation on the button that was actually
+    // tapped (i.e. the Continue button). The Back button never sets
+    // _tapped, so it stays as a plain disabled button during loading.
     final showThinking =
         _tapped && state.isLoading && !widget.showLoadingOverlay;
 
@@ -138,10 +168,10 @@ class _OneTapAppButtonState extends State<_OneTapAppButton> {
           label: label ?? '',
           variant: widget.variant,
           size: widget.size,
-          onPressed: _tapped || state.isLoading ? null : _onPressed,
+          onPressed: _tapped || blocBusy ? null : _onPressed,
         );
 
-        return showThinking
+        final child = showThinking
             ? Stack(
                 children: [
                   Visibility(
@@ -155,6 +185,11 @@ class _OneTapAppButtonState extends State<_OneTapAppButton> {
                 ],
               )
             : button;
+
+        return Padding(
+          padding: const EdgeInsets.only(top: Spacing.md),
+          child: child,
+        );
       },
     );
   }

--- a/lib/simulator/prompt/prompt.dart
+++ b/lib/simulator/prompt/prompt.dart
@@ -15,6 +15,8 @@ You drive the conversation step by step. The user does NOT type messages — the
 
 CRITICAL: Each step in the conversation MUST create a NEW surface with a unique surfaceId. Do NOT update a previous surface — always create a fresh one. This is how the app knows to show a new screen. When the user taps a button or interacts with a widget, respond by creating a new surface for the next step.
 
+CRITICAL — after Back then Continue: If the user went backward in the flow and then taps Continue, you MUST still output a **createSurface** (or equivalent) with a **surfaceId that is new and unused** in this conversation. Never reuse the surfaceId of the step they are currently viewing as the "next" screen — the client maps pages by surfaceId; reusing the same id leaves them on the same page with no forward progress.
+
 The flow should feel like a guided conversation:
 1. The user taps a button or starts the conversation.
 2. You respond by creating a NEW surface that contains EVERYTHING for the next step: your conversational response (as a Text component inside the surface), the question, interactive widgets, and a "Next" button. ALL content goes inside the surface — do NOT output any text outside the JSON blocks.
@@ -24,11 +26,11 @@ The flow should feel like a guided conversation:
 CRITICAL: Do NOT output conversational text outside the JSON blocks. ALL text must be inside the surface as Text components. The only output should be the createSurface and updateComponents JSON blocks with no text before, after, or between them.
 
 Example flow for retirement planning:
-- Surface 1: SectionHeader(title: "Welcome!", subtitle: "Let's plan your retirement.") + RadioCard + AppButton
-- Surface 2: SectionHeader(title: "Your Timeline", subtitle: "Great choice! Now let's figure out your timeline.") + GCNSlider + AppButton
-- Surface 3: SectionHeader(title: "Your Income", subtitle: "Got it! Next, let's look at your income.") + GCNSlider with $ prefix + AppButton
-- Surface 4: SectionHeader(title: "Current Savings", subtitle: "Almost there!") + GCNSlider with $ prefix + AppButton(showLoadingOverlay: true)
-- Surface 5: Summary & Recommended Products (REQUIRED — see below)
+- Surface 1: SectionHeader(title: "Welcome!", subtitle: "Let's plan your retirement.") + RadioCard + AppButton (Continue only — first step)
+- Surface 2: SectionHeader(title: "Your Timeline", subtitle: "Great choice! Now let's figure out your timeline.") + GCNSlider + Row(Back AppButton + Continue AppButton)
+- Surface 3: SectionHeader(title: "Your Income", subtitle: "Got it! Next, let's look at your income.") + GCNSlider with $ prefix + Row(Back AppButton + Continue AppButton)
+- Surface 4: SectionHeader(title: "Current Savings", subtitle: "Almost there!") + GCNSlider with $ prefix + Row(Back AppButton + Continue AppButton with showLoadingOverlay: true)
+- Surface 5: Summary & Recommended Products (no navigation Row — use NextStepsBar instead) (REQUIRED — see below)
 
 IMPORTANT: The AppButton on the LAST question screen (the one before the summary) MUST set "showLoadingOverlay": true. This triggers a loading animation while the summary dashboard is being generated.
 
@@ -102,7 +104,7 @@ WRONG — never do this:
 Each surface should have:
 - A SectionHeader as the FIRST child with a title for the step and a subtitle with a brief conversational response (1-2 sentences)
 - One focused question with interactive widgets to answer it (or the summary)
-- An AppButton to proceed to the next step
+- Navigation buttons at the bottom (see Navigation Buttons below)
 
 Do NOT present large walls of text or dump all information at once. Do NOT reuse or update a previous surfaceId — always generate a new unique one.
 
@@ -125,6 +127,24 @@ WRONG (text outside JSON blocks):
 Great choice! Now let's figure out your timeline.
 ```json
 { "version": "v0.9", "createSurface": { ... } }
+```
+
+## Navigation Buttons
+Every question surface (NOT the final summary) must include navigation buttons as the LAST child of the main Column:
+
+**First step only**: A single AppButton (variant: "filled", size: "large") to proceed.
+
+**Steps 2 and beyond**: A Row containing TWO AppButtons:
+1. Back button: label "Back", variant "outlined", size "large", action: {"event": {"name": "go_back"}}
+2. Continue button: variant "filled", size "large", with the normal proceed action.
+
+The Back button ALWAYS uses exactly this action: {"event": {"name": "go_back"}} — no additional context is needed.
+
+Example for step 2+:
+```json
+{"id": "btn_row", "component": "Row", "justify": "spaceEvenly", "children": ["back_btn", "next_btn"]},
+{"id": "back_btn", "component": "AppButton", "label": "Back", "variant": "outlined", "size": "large", "action": {"event": {"name": "go_back"}}},
+{"id": "next_btn", "component": "AppButton", "label": "Continue", "variant": "filled", "size": "large", "action": {"event": {"name": "next_step"}}}
 ```
 
 ## Rules

--- a/lib/simulator/repository/simulator_repository.dart
+++ b/lib/simulator/repository/simulator_repository.dart
@@ -39,6 +39,13 @@ class SimulatorRepository {
   final List<ChatMessage> _history = [];
   late String _systemPrompt;
 
+  /// The current step index for history tracking.
+  ///
+  /// Set this when navigating between steps so that [_handleSend] can
+  /// truncate stale future history entries when continuing from a revisited
+  /// step.
+  int currentStep = 0;
+
   final _controller = StreamController<SimulatorConversationEvent>.broadcast();
 
   /// Stream of conversation events (text, surfaces, errors, waiting state).
@@ -108,6 +115,13 @@ class SimulatorRepository {
   }
 
   Future<void> _handleSend(ChatMessage message) async {
+    // If continuing from a revisited step, truncate future history so the
+    // LLM only sees the conversation up to the current step.
+    final expectedLength = (currentStep + 1) * 2;
+    if (_history.length > expectedLength) {
+      _history.removeRange(expectedLength, _history.length);
+    }
+
     _history.add(_convertDataPartsToText(message));
 
     final messages = [

--- a/lib/simulator/view/simulator_view.dart
+++ b/lib/simulator/view/simulator_view.dart
@@ -44,12 +44,19 @@ class _SimulatorViewState extends State<SimulatorView> {
             previous.currentPageIndex != current.currentPageIndex,
         listener: (context, state) {
           if (mounted && _pageController.hasClients && state.pages.isNotEmpty) {
+            final bloc = context.read<SimulatorBloc>();
             unawaited(
-              _pageController.animateToPage(
-                state.currentPageIndex,
-                duration: const Duration(milliseconds: 1200),
-                curve: Curves.easeInOutCubic,
-              ),
+              _pageController
+                  .animateToPage(
+                    state.currentPageIndex,
+                    duration: const Duration(milliseconds: 1200),
+                    curve: Curves.easeInOutCubic,
+                  )
+                  .then((_) {
+                    if (state.isNavigatingBack && mounted) {
+                      bloc.add(const SimulatorForwardPagesTruncated());
+                    }
+                  }),
             );
           }
         },
@@ -57,6 +64,8 @@ class _SimulatorViewState extends State<SimulatorView> {
             previous.pages != current.pages ||
             previous.isLoading != current.isLoading ||
             previous.status != current.status ||
+            previous.currentPageIndex != current.currentPageIndex ||
+            previous.isNavigatingBack != current.isNavigatingBack ||
             previous.hasPendingNavigation != current.hasPendingNavigation ||
             previous.showLoadingOverlay != current.showLoadingOverlay,
         builder: (context, state) {
@@ -220,6 +229,7 @@ class _FadingPageView extends StatelessWidget {
       animation: controller,
       builder: (context, child) {
         return PageView.builder(
+          physics: const NeverScrollableScrollPhysics(),
           controller: controller,
           itemCount: itemCount,
           itemBuilder: (context, pageIndex) {

--- a/test/simulator/bloc/simulator_bloc_test.dart
+++ b/test/simulator/bloc/simulator_bloc_test.dart
@@ -46,8 +46,16 @@ void main() {
       expect(state.pages, isEmpty);
       expect(state.currentPageIndex, 0);
       expect(state.isLoading, isFalse);
+      expect(state.isNavigatingBack, isFalse);
+      expect(state.pendingPageIndex, isNull);
+      expect(state.hasPendingNavigation, isFalse);
       expect(state.showLoadingOverlay, isFalse);
       expect(state.error, isNull);
+    });
+
+    test('hasPendingNavigation is true when pendingPageIndex is set', () {
+      const state = SimulatorState(pendingPageIndex: 2);
+      expect(state.hasPendingNavigation, isTrue);
     });
 
     test('copyWith returns new instance with overridden values', () {
@@ -65,6 +73,12 @@ void main() {
       expect(updated.currentPageIndex, 0);
       expect(updated.isLoading, isTrue);
       expect(updated.error, 'oops');
+    });
+
+    test('copyWith overrides isNavigatingBack', () {
+      const state = SimulatorState();
+      final updated = state.copyWith(isNavigatingBack: true);
+      expect(updated.isNavigatingBack, isTrue);
     });
 
     test('copyWith preserves values when not overridden', () {
@@ -134,6 +148,16 @@ void main() {
     test('$SimulatorErrorOccurred holds message', () {
       const event = SimulatorErrorOccurred('fail');
       expect(event.message, 'fail');
+    });
+
+    test('$SimulatorBackPressed can be constructed', () {
+      const event = SimulatorBackPressed();
+      expect(event, isA<SimulatorEvent>());
+    });
+
+    test('$SimulatorForwardPagesTruncated can be constructed', () {
+      const event = SimulatorForwardPagesTruncated();
+      expect(event, isA<SimulatorEvent>());
     });
   });
 
@@ -253,6 +277,9 @@ void main() {
             .having((s) => s.pages, 'pages', hasLength(2))
             .having((s) => s.currentPageIndex, 'currentPageIndex', 0),
       ],
+      verify: (_) {
+        verify(() => repository.currentStep = 0).called(1);
+      },
     );
 
     blocTest<SimulatorBloc, SimulatorState>(
@@ -398,6 +425,184 @@ void main() {
       act: (bloc) => bloc.add(const SimulatorMessageSent('hello')),
       verify: (_) {
         verify(() => repository.sendMessage('hello')).called(1);
+      },
+    );
+
+    group('$SimulatorBackPressed', () {
+      blocTest<SimulatorBloc, SimulatorState>(
+        'decrements currentPageIndex when not on first page',
+        build: () => SimulatorBloc(simulatorRepository: repository),
+        seed: () => const SimulatorState(
+          pages: [
+            [AiSurfaceDisplayMessage('s1')],
+            [AiSurfaceDisplayMessage('s2')],
+            [AiSurfaceDisplayMessage('s3')],
+          ],
+          currentPageIndex: 2,
+        ),
+        act: (bloc) => bloc.add(const SimulatorBackPressed()),
+        expect: () => [
+          isA<SimulatorState>()
+              .having((s) => s.currentPageIndex, 'currentPageIndex', 1)
+              .having((s) => s.pages, 'pages', hasLength(3))
+              .having((s) => s.isNavigatingBack, 'isNavigatingBack', isTrue),
+        ],
+      );
+
+      blocTest<SimulatorBloc, SimulatorState>(
+        'does nothing when already on first page',
+        build: () => SimulatorBloc(simulatorRepository: repository),
+        seed: () => const SimulatorState(
+          pages: [
+            [AiSurfaceDisplayMessage('s1')],
+          ],
+        ),
+        act: (bloc) => bloc.add(const SimulatorBackPressed()),
+        expect: () => <SimulatorState>[],
+      );
+
+      blocTest<SimulatorBloc, SimulatorState>(
+        'sets repository.currentStep to the new index',
+        build: () => SimulatorBloc(simulatorRepository: repository),
+        seed: () => const SimulatorState(
+          pages: [
+            [AiSurfaceDisplayMessage('s1')],
+            [AiSurfaceDisplayMessage('s2')],
+          ],
+          currentPageIndex: 1,
+        ),
+        act: (bloc) => bloc.add(const SimulatorBackPressed()),
+        verify: (_) {
+          verify(() => repository.currentStep = 0).called(1);
+        },
+      );
+    });
+
+    group('$SimulatorForwardPagesTruncated', () {
+      blocTest<SimulatorBloc, SimulatorState>(
+        'removes forward pages and clears isNavigatingBack',
+        build: () => SimulatorBloc(simulatorRepository: repository),
+        seed: () => const SimulatorState(
+          pages: [
+            [AiSurfaceDisplayMessage('s1')],
+            [AiSurfaceDisplayMessage('s2')],
+            [AiSurfaceDisplayMessage('s3')],
+          ],
+          currentPageIndex: 1,
+          isNavigatingBack: true,
+        ),
+        act: (bloc) => bloc.add(const SimulatorForwardPagesTruncated()),
+        expect: () => [
+          isA<SimulatorState>()
+              .having((s) => s.pages, 'pages', hasLength(2))
+              .having((s) => s.currentPageIndex, 'currentPageIndex', 1)
+              .having((s) => s.isNavigatingBack, 'isNavigatingBack', isFalse),
+        ],
+      );
+    });
+
+    blocTest<SimulatorBloc, SimulatorState>(
+      '$SimulatorSurfaceReceived after back navigation appends new page',
+      build: () => SimulatorBloc(simulatorRepository: repository),
+      seed: () => const SimulatorState(
+        pages: [
+          [AiSurfaceDisplayMessage('s1')],
+          [AiSurfaceDisplayMessage('s2')],
+        ],
+        currentPageIndex: 1,
+      ),
+      act: (bloc) => bloc.add(const SimulatorSurfaceReceived('s3')),
+      expect: () => [
+        isA<SimulatorState>()
+            .having((s) => s.pages, 'pages', hasLength(3))
+            .having((s) => s.currentPageIndex, 'currentPageIndex', 2),
+      ],
+    );
+
+    blocTest<SimulatorBloc, SimulatorState>(
+      '$SimulatorSurfaceReceived trims stale forward pages before appending',
+      build: () => SimulatorBloc(simulatorRepository: repository),
+      seed: () => const SimulatorState(
+        pages: [
+          [AiSurfaceDisplayMessage('s1')],
+          [AiSurfaceDisplayMessage('s2')],
+          [AiSurfaceDisplayMessage('s3')],
+        ],
+        // Simulates being on page 0 after back with forward pages still
+        // present (truncation hasn't fired yet).
+        isNavigatingBack: true,
+      ),
+      act: (bloc) => bloc.add(const SimulatorSurfaceReceived('s4')),
+      expect: () => [
+        isA<SimulatorState>()
+            .having((s) => s.pages, 'pages', hasLength(2))
+            .having((s) => s.currentPageIndex, 'currentPageIndex', 1)
+            .having((s) => s.isNavigatingBack, 'isNavigatingBack', isFalse),
+      ],
+    );
+
+    blocTest<SimulatorBloc, SimulatorState>(
+      '$SimulatorSurfaceReceived navigates immediately for known surface '
+      'even while loading',
+      build: () => SimulatorBloc(simulatorRepository: repository),
+      seed: () => const SimulatorState(
+        pages: [
+          [AiSurfaceDisplayMessage('surface_1')],
+          [AiSurfaceDisplayMessage('surface_2')],
+        ],
+        currentPageIndex: 1,
+        isLoading: true,
+      ),
+      act: (bloc) => bloc.add(const SimulatorSurfaceReceived('surface_1')),
+      expect: () => [
+        isA<SimulatorState>()
+            .having((s) => s.currentPageIndex, 'currentPageIndex', 0)
+            .having(
+              (s) => s.pendingPageIndex,
+              'pendingPageIndex',
+              isNull,
+            )
+            .having(
+              (s) => s.showLoadingOverlay,
+              'showLoadingOverlay',
+              isFalse,
+            ),
+      ],
+      verify: (_) {
+        verify(() => repository.currentStep = 0).called(1);
+      },
+    );
+
+    blocTest<SimulatorBloc, SimulatorState>(
+      '$SimulatorSurfaceReceived clears isNavigatingBack',
+      build: () => SimulatorBloc(simulatorRepository: repository),
+      seed: () => const SimulatorState(
+        pages: [
+          [AiSurfaceDisplayMessage('s1')],
+        ],
+        isNavigatingBack: true,
+      ),
+      act: (bloc) => bloc.add(const SimulatorSurfaceReceived('s2')),
+      expect: () => [
+        isA<SimulatorState>().having(
+          (s) => s.isNavigatingBack,
+          'isNavigatingBack',
+          isFalse,
+        ),
+      ],
+    );
+
+    blocTest<SimulatorBloc, SimulatorState>(
+      '$SimulatorSurfaceReceived sets repository.currentStep',
+      build: () => SimulatorBloc(simulatorRepository: repository),
+      seed: () => const SimulatorState(
+        pages: [
+          [AiSurfaceDisplayMessage('s1')],
+        ],
+      ),
+      act: (bloc) => bloc.add(const SimulatorSurfaceReceived('s2')),
+      verify: (_) {
+        verify(() => repository.currentStep = 1).called(1);
       },
     );
 

--- a/test/simulator/catalog/items/app_button_catalog_item_test.dart
+++ b/test/simulator/catalog/items/app_button_catalog_item_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:bloc_test/bloc_test.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
@@ -165,6 +167,182 @@ void main() {
         expect(event.name, 'get_started');
         expect(event.context, {'page': 'home'});
       });
+
+      testWidgets(
+        'go_back action dispatches SimulatorBackPressed to bloc',
+        (tester) async {
+          final bloc = _MockSimulatorBloc();
+          when(() => bloc.state).thenReturn(const SimulatorState());
+          await _pumpWithBloc(
+            tester,
+            bloc,
+            _data(
+              label: 'Back',
+              variant: 'outlined',
+              action: {
+                'event': {'name': 'go_back'},
+              },
+            ),
+          );
+
+          await tester.tap(find.text('Back'));
+          await tester.pump();
+
+          verify(() => bloc.add(const SimulatorBackPressed())).called(1);
+        },
+      );
+
+      testWidgets(
+        'button is disabled when bloc is loading',
+        (tester) async {
+          final bloc = _MockSimulatorBloc();
+          when(() => bloc.state).thenReturn(
+            const SimulatorState(isLoading: true),
+          );
+          final events = <UiEvent>[];
+          await _pumpWithBloc(
+            tester,
+            bloc,
+            _data(),
+            dispatchEvent: events.add,
+          );
+
+          await tester.tap(find.text('Get Started'));
+          await tester.pump();
+
+          expect(events, isEmpty);
+        },
+      );
+
+      testWidgets(
+        'button is disabled during back navigation',
+        (tester) async {
+          final bloc = _MockSimulatorBloc();
+          when(() => bloc.state).thenReturn(
+            const SimulatorState(isNavigatingBack: true),
+          );
+          final events = <UiEvent>[];
+          await _pumpWithBloc(
+            tester,
+            bloc,
+            _data(),
+            dispatchEvent: events.add,
+          );
+
+          await tester.tap(find.text('Get Started'));
+          await tester.pump();
+
+          expect(events, isEmpty);
+        },
+      );
+
+      testWidgets(
+        're-enables after currentPageIndex changes',
+        (tester) async {
+          final controller = StreamController<SimulatorState>.broadcast();
+          final bloc = _MockSimulatorBloc();
+          whenListen(
+            bloc,
+            controller.stream,
+            initialState: const SimulatorState(),
+          );
+          when(() => bloc.state).thenReturn(const SimulatorState());
+
+          final eventsWrapper = <UiEvent>[];
+          await _pumpWithBloc(
+            tester,
+            bloc,
+            _data(),
+            dispatchEvent: eventsWrapper.add,
+          );
+
+          // First tap disables the button.
+          await tester.tap(find.text('Get Started'));
+          await tester.pump();
+          expect(eventsWrapper, hasLength(1));
+
+          // Page index changes (e.g. back navigation landed on this page).
+          controller.add(const SimulatorState(currentPageIndex: 1));
+          await tester.pump();
+
+          // Button should be re-enabled — second tap dispatches.
+          eventsWrapper.clear();
+          controller.add(const SimulatorState());
+          await tester.pump();
+
+          await tester.tap(find.text('Get Started'));
+          await tester.pump();
+          expect(eventsWrapper, hasLength(1));
+          await controller.close();
+        },
+      );
+
+      testWidgets(
+        're-enables after loading ends without currentPageIndex change',
+        (tester) async {
+          final controller = StreamController<SimulatorState>.broadcast();
+          final bloc = _MockSimulatorBloc();
+          whenListen(
+            bloc,
+            controller.stream,
+            initialState: const SimulatorState(),
+          );
+          when(() => bloc.state).thenReturn(
+            const SimulatorState(),
+          );
+
+          final eventsWrapper = <UiEvent>[];
+          await _pumpWithBloc(
+            tester,
+            bloc,
+            _data(),
+            dispatchEvent: eventsWrapper.add,
+          );
+
+          await tester.tap(find.text('Get Started'));
+          await tester.pump();
+          expect(eventsWrapper, hasLength(1));
+
+          controller.add(
+            const SimulatorState(isLoading: true),
+          );
+          await tester.pump();
+
+          controller.add(const SimulatorState());
+          await tester.pump();
+
+          eventsWrapper.clear();
+          await tester.tap(find.text('Get Started'));
+          await tester.pump();
+
+          expect(eventsWrapper, hasLength(1));
+          await controller.close();
+        },
+      );
     });
   });
+}
+
+Future<void> _pumpWithBloc(
+  WidgetTester tester,
+  SimulatorBloc bloc,
+  Map<String, Object?> data, {
+  void Function(UiEvent)? dispatchEvent,
+}) async {
+  await tester.pumpWidget(
+    BlocProvider<SimulatorBloc>.value(
+      value: bloc,
+      child: MaterialApp(
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        home: Scaffold(
+          body: Builder(
+            builder: (context) => appButtonItem.widgetBuilder(
+              _context(context, data, dispatchEvent: dispatchEvent),
+            ),
+          ),
+        ),
+      ),
+    ),
+  );
 }

--- a/test/simulator/repository/simulator_repository_test.dart
+++ b/test/simulator/repository/simulator_repository_test.dart
@@ -119,6 +119,84 @@ void main() {
       });
     });
 
+    group('currentStep and history truncation', () {
+      test('currentStep defaults to 0', () {
+        expect(repository.currentStep, 0);
+      });
+
+      test('currentStep can be read and written', () {
+        repository.currentStep = 3;
+        expect(repository.currentStep, 3);
+      });
+
+      test(
+        'truncates history beyond currentStep when sending after going back',
+        () async {
+          await repository.startConversation();
+
+          // Build up history, advancing currentStep after each send just
+          // like the bloc does when a new surface arrives.
+          await repository.sendMessage('step 0');
+          repository.currentStep = 1;
+          await repository.sendMessage('step 1');
+          repository.currentStep = 2;
+          await repository.sendMessage('step 2');
+
+          // Record how many messages the LLM saw on the 3rd send.
+          final beforeBacktrack = verify(
+            () => chatModel.sendStream(captureAny()),
+          ).captured;
+          final messagesAtStep2 =
+              (beforeBacktrack.last as List<ChatMessage>).length;
+
+          // Simulate going back to step 0 and continuing.
+          repository.currentStep = 0;
+          await repository.sendMessage('step 0 redo');
+
+          final afterBacktrack = verify(
+            () => chatModel.sendStream(captureAny()),
+          ).captured;
+          final messagesAfterTruncation =
+              (afterBacktrack.last as List<ChatMessage>).length;
+
+          // After truncation the LLM should see fewer messages than before
+          // (system + step0 user + step0 model + new user vs. the full
+          // chain that included step1 and step2).
+          expect(messagesAfterTruncation, lessThan(messagesAtStep2));
+        },
+      );
+
+      test(
+        'does not truncate when currentStep matches history',
+        () async {
+          await repository.startConversation();
+
+          // Advance currentStep in lockstep with sends.
+          await repository.sendMessage('step 0');
+          repository.currentStep = 1;
+          await repository.sendMessage('step 1');
+          repository.currentStep = 2;
+          await repository.sendMessage('step 2');
+
+          final captured = verify(
+            () => chatModel.sendStream(captureAny()),
+          ).captured;
+
+          // Each successive call should see more messages than the previous.
+          final lengths = [
+            for (final c in captured) (c as List<ChatMessage>).length,
+          ];
+          for (var i = 1; i < lengths.length; i++) {
+            expect(
+              lengths[i],
+              greaterThan(lengths[i - 1]),
+              reason: 'send $i should see more messages than send ${i - 1}',
+            );
+          }
+        },
+      );
+    });
+
     group('AI response streaming', () {
       test('emits text events for plain text AI responses', () async {
         when(() => chatModel.sendStream(any())).thenAnswer(


### PR DESCRIPTION
## Summary
- Adds a Back button (outlined) alongside the Continue button on steps 2+ of the simulator wizard, allowing users to revisit and modify previous answers
- When going back and continuing, forward history is truncated so the LLM generates a fresh response from the revisited step
- Back animation fades out the current page smoothly via an `isNavigatingBack` guard that keeps forward pages alive during the transition but disables all buttons to prevent race conditions
- Integrates with the new design-system loaders from #240: Continue shows `ThinkingAnimation`, Back simply disables

### Key changes
- **System prompt**: Instructs LLM to generate a Row with Back + Continue buttons on steps 2+
- **AppButton catalog item**: Intercepts `go_back` action to dispatch `SimulatorBackPressed` directly (no LLM call); re-enables `_tapped` state on page index change
- **Bloc**: `SimulatorBackPressed` / `SimulatorForwardPagesTruncated` events with `isNavigatingBack` flag; safety-net truncation in `_onSurfaceReceived`
- **Repository**: `currentStep` field + history truncation in `_handleSend` when continuing from a revisited step

## Test plan
- [x] Bloc tests: back pressed (decrement, no-op on first page, sets currentStep), forward pages truncated, surface received (trims stale pages, clears isNavigatingBack, sets currentStep)
- [x] Repository tests: currentStep default/read/write, history truncation after backtrack, no truncation on normal forward flow
- [x] AppButton tests: go_back dispatches SimulatorBackPressed, disabled during loading, disabled during back navigation
- [x] State tests: isNavigatingBack default/copyWith, hasPendingNavigation getter
- [x] Manual: tap through 3+ steps, go back, change answer, continue — verify fresh surface and smooth animation

🤖 Generated with [Claude Code](https://claude.com/claude-code)