### PR TITLE
fix: pop dangling user turn on zero-chunk failure; rename SimulatorLoading

### DIFF
--- a/lib/simulator/bloc/simulator_bloc.dart
+++ b/lib/simulator/bloc/simulator_bloc.dart
@@ -18,7 +18,7 @@ class SimulatorBloc extends Bloc<SimulatorEvent, SimulatorState> {
     on<SimulatorForwardPagesTruncated>(_onForwardPagesTruncated);
     on<SimulatorSurfaceReceived>(_onSurfaceReceived);
     on<SimulatorContentReceived>(_onContentReceived);
-    on<SimulatorLoading>(_onLoading);
+    on<SimulatorLoadingChanged>(_onLoadingChanged);
     on<SimulatorLoadingOverlayRequested>(_onLoadingOverlayRequested);
     on<SimulatorErrorOccurred>(_onErrorOccurred);
     on<SimulatorRetried>(_onRetried);
@@ -37,7 +37,7 @@ class SimulatorBloc extends Bloc<SimulatorEvent, SimulatorState> {
       if (isClosed) return;
       switch (event) {
         case SimulatorConversationWaiting(:final isWaiting):
-          add(SimulatorLoading(isLoading: isWaiting));
+          add(SimulatorLoadingChanged(isLoading: isWaiting));
         case SimulatorConversationTextReceived(:final text):
           add(SimulatorContentReceived(AiTextDisplayMessage(text)));
         case SimulatorConversationSurfaceAdded(:final surfaceId):
@@ -189,8 +189,8 @@ class SimulatorBloc extends Bloc<SimulatorEvent, SimulatorState> {
     emit(state.copyWith(pages: pages, currentPageIndex: currentPageIndex));
   }
 
-  void _onLoading(
-    SimulatorLoading event,
+  void _onLoadingChanged(
+    SimulatorLoadingChanged event,
     Emitter<SimulatorState> emit,
   ) {
     final withLoading = state.copyWith(isLoading: event.isLoading);

--- a/lib/simulator/bloc/simulator_event.dart
+++ b/lib/simulator/bloc/simulator_event.dart
@@ -41,9 +41,9 @@ final class SimulatorContentReceived extends SimulatorEvent {
   final DisplayMessage message;
 }
 
-/// Loading state when LLM is processing a request
-final class SimulatorLoading extends SimulatorEvent {
-  const SimulatorLoading({required this.isLoading});
+/// The LLM's waiting state toggled (started or stopped processing a request).
+final class SimulatorLoadingChanged extends SimulatorEvent {
+  const SimulatorLoadingChanged({required this.isLoading});
 
   final bool isLoading;
 }

--- a/lib/simulator/repository/simulator_repository.dart
+++ b/lib/simulator/repository/simulator_repository.dart
@@ -142,9 +142,14 @@ class SimulatorRepository {
       }
       _history.add(ChatMessage.model(buffer.toString()));
     } on Object catch (e, st) {
-      // Save whatever was streamed so retry has full context.
       if (buffer.isNotEmpty) {
+        // Save whatever was streamed so retry has full context.
         _history.add(ChatMessage.model(buffer.toString()));
+      } else {
+        // Zero chunks arrived — pop the dangling user message so history
+        // doesn't end with two consecutive user turns on the next send,
+        // which Firebase AI rejects as INVALID_ARGUMENT.
+        _history.removeLast();
       }
       await _errorReporting.recordError(e, st, reason: 'AI sendStream error');
       _controller.add(SimulatorConversationError('AI error: $e'));

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -6,6 +6,7 @@ import FlutterMacOS
 import Foundation
 
 import audioplayers_darwin
+import firebase_ai
 import firebase_app_check
 import firebase_auth
 import firebase_core
@@ -16,6 +17,7 @@ import video_player_avfoundation
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   AudioplayersDarwinPlugin.register(with: registry.registrar(forPlugin: "AudioplayersDarwinPlugin"))
+  FirebaseAIPlugin.register(with: registry.registrar(forPlugin: "FirebaseAIPlugin"))
   FLTFirebaseAppCheckPlugin.register(with: registry.registrar(forPlugin: "FLTFirebaseAppCheckPlugin"))
   FLTFirebaseAuthPlugin.register(with: registry.registrar(forPlugin: "FLTFirebaseAuthPlugin"))
   FLTFirebaseCorePlugin.register(with: registry.registrar(forPlugin: "FLTFirebaseCorePlugin"))

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1636,4 +1636,4 @@ packages:
     version: "3.1.3"
 sdks:
   dart: ">=3.11.0 <4.0.0"
-  flutter: ">=3.41.4"
+  flutter: ">=3.41.4 <4.0.0"

--- a/test/simulator/bloc/simulator_bloc_test.dart
+++ b/test/simulator/bloc/simulator_bloc_test.dart
@@ -140,8 +140,8 @@ void main() {
       expect(event.message, isA<AiTextDisplayMessage>());
     });
 
-    test('$SimulatorLoading holds isLoading', () {
-      const event = SimulatorLoading(isLoading: true);
+    test('$SimulatorLoadingChanged holds isLoading', () {
+      const event = SimulatorLoadingChanged(isLoading: true);
       expect(event.isLoading, isTrue);
     });
 
@@ -312,9 +312,9 @@ void main() {
     );
 
     blocTest<SimulatorBloc, SimulatorState>(
-      '$SimulatorLoading emits state with isLoading',
+      '$SimulatorLoadingChanged emits state with isLoading',
       build: () => SimulatorBloc(simulatorRepository: repository),
-      act: (bloc) => bloc.add(const SimulatorLoading(isLoading: true)),
+      act: (bloc) => bloc.add(const SimulatorLoadingChanged(isLoading: true)),
       expect: () => [
         isA<SimulatorState>().having((s) => s.isLoading, 'isLoading', isTrue),
       ],
@@ -386,7 +386,7 @@ void main() {
         // Then loading finishes → pending navigation flushes.
         bloc
           ..add(const SimulatorSurfaceReceived('surface_2'))
-          ..add(const SimulatorLoading(isLoading: false));
+          ..add(const SimulatorLoadingChanged(isLoading: false));
       },
       skip: 1,
       expect: () => [

--- a/test/simulator/repository/simulator_repository_test.dart
+++ b/test/simulator/repository/simulator_repository_test.dart
@@ -293,6 +293,51 @@ void main() {
         final errors = events.whereType<SimulatorConversationError>();
         expect(errors, isNotEmpty);
       });
+
+      test(
+        'pops the dangling user message when the stream fails with zero '
+        'chunks so the next send does not produce two consecutive user turns',
+        () async {
+          // First call: fail immediately with no chunks.
+          // Second call: succeed.
+          var callCount = 0;
+          when(() => chatModel.sendStream(any())).thenAnswer((_) {
+            callCount++;
+            if (callCount == 1) {
+              return Stream<ChatResult<ChatMessage>>.error(
+                Exception('network blip'),
+              );
+            }
+            return Stream.fromIterable([
+              ChatResult(output: ChatMessage.model('ok')),
+            ]);
+          });
+
+          await repository.startConversation();
+          await repository.sendMessage('first attempt');
+          await Future<void>.delayed(Duration.zero);
+          await repository.sendMessage('second attempt');
+
+          final captured = verify(
+            () => chatModel.sendStream(captureAny()),
+          ).captured;
+
+          // Walk the history the LLM saw on the second call and confirm no
+          // two adjacent user turns (the dangling first-attempt user
+          // message should have been popped).
+          final secondCallMessages = captured.last as List<ChatMessage>;
+          for (var i = 1; i < secondCallMessages.length; i++) {
+            expect(
+              secondCallMessages[i].role == ChatMessageRole.user &&
+                  secondCallMessages[i - 1].role == ChatMessageRole.user,
+              isFalse,
+              reason:
+                  'history must never contain two consecutive user turns: '
+                  '${secondCallMessages.map((m) => m.role).toList()}',
+            );
+          }
+        },
+      );
     });
 
     group('dispose', () {


### PR DESCRIPTION
## Summary

Addresses two architectural issues surfaced during review of the GenUI + VGV Architecture blog post (VGVentures/vgv-website-claude#180). Both were real bugs in this repo, not article inaccuracies.

- **History corruption on zero-chunk failure.** `SimulatorRepository._handleSend` appended the user message before streaming but only conditionally appended the model reply, so if `sendStream` threw (or the stream closed with zero chunks), `_history` ended on a user turn. The next send produced two consecutive user turns, which Firebase AI rejects with `INVALID_ARGUMENT`. Fix: pop the dangling user message when the buffer is empty — minimal and symmetric, and preserves the rest of the conversation instead of resetting it over a transient blip.
- **`SimulatorLoading` violated the past-tense event naming convention.** Every other event in the bloc follows the past-tense rule (`SimulatorStarted`, `SimulatorMessageSent`, `SimulatorSurfaceReceived`, …). Renamed to `SimulatorLoadingChanged` — it's a boolean toggle carrying `isLoading: true|false`, so "Changed" is the accurate past-tense form. Avoids collision with the existing `SimulatorLoadingOverlayRequested`.

## Test plan

- [x] `fvm dart format` clean
- [x] `fvm flutter analyze` on changed files — no issues
- [x] `fvm flutter test` for bloc + repository suites — 60/60 green, including new regression test that walks post-retry history and asserts no two consecutive user turns

🤖 Generated with [Claude Code](https://claude.com/claude-code)