### PR TITLE
feat: OpenUI Lang transport (v0.5)

### DIFF
--- a/lib/simulator/catalog/finance_catalog.dart
+++ b/lib/simulator/catalog/finance_catalog.dart
@@ -11,91 +11,74 @@ const financeCatalogId = 'com.vgv.finance_catalog';
 /// Usage guidance appended to the system prompt so the LLM knows when and how
 /// to use the finance-specific widgets beyond what the JSON schema describes.
 const _financeWidgetRules =
-    '''
-IMPORTANT: Every A2UI JSON message MUST include "version": "v0.9" at the top level, and when creating a surface you MUST use this exact catalogId: "$financeCatalogId". Do NOT invent or guess a different catalogId.
-
-Example createSurface:
-```json
-{
-  "version": "v0.9",
-  "createSurface": {
-    "surfaceId": "unique_id",
-    "catalogId": "$financeCatalogId",
-    "sendDataModel": true
-  }
-}
-```
-
-Use the AppButton widget to present clear calls-to-action, such as navigating to a detailed view, confirming a choice, or starting a workflow.
+    r'''
+Use the AppButton widget to present clear calls-to-action.
 - variant: "filled" for primary actions, "outlined" for secondary actions.
 - size: "large" for prominent actions, "small" for inline or less prominent actions.
 - isLoading: Set to true only when an async operation is in progress.
 - For back navigation, use variant "outlined" with the exact action: {"event": {"name": "go_back"}}.
 
-Use the EmojiCard widget to display a set of categorized options or highlights as emoji-labelled cards in a responsive grid.
+Use the EmojiCard widget to display categorized options or highlights as emoji-labelled cards in a responsive grid.
 
 Use the LineChart widget to visualize trends over time (e.g. monthly spending, account balance history).
 
-Use the BarChart widget to compare discrete values across multiple series and categories (e.g. monthly spending by account, budget vs. actual by category). Use 1–3 series and assign a distinct color to each. Always provide yAxisLabels ordered bottom to top.
+Use the BarChart widget to compare discrete values across multiple series and categories. Use 1–3 series and assign a distinct color to each. Always provide yAxisLabels ordered bottom to top.
 
 Use the MetricCard widget to highlight key financial metrics (e.g. total spending, savings rate, net worth).
 
-Use the RadioCard widget to present a set of mutually exclusive choices (e.g. profile type, plan selection). Exactly one option should have isSelected: true.
+Use the RadioCard widget to present a set of mutually exclusive choices. CRITICAL: Every option MUST include "isSelected" — set exactly one to true and ALL others to false. Never omit isSelected on any option.
 
-Use the FilterBar widget to let the user filter data by category (e.g. spending categories, account types). Include an "action" to refresh content when filters change. Example:
-{"id": "category_filter", "component": "FilterBar", "categories": [{"label": "Food", "color": "pink", "isSelected": true}, {"label": "Transport", "color": "aqua", "isSelected": true}], "action": {"event": {"name": "filter_changed"}}}
+Use the FilterBar widget to let the user filter data by category. Include an "action" to refresh content when filters change. Example:
+```openui
+category_filter = FilterBar([{"label": "Food", "color": "pink", "isSelected": true}, {"label": "Transport", "color": "aqua", "isSelected": true}], {"event": {"name": "filter_changed"}})
+```
 
 IMPORTANT: When using FilterBar to filter charts or data, ALWAYS include an "action" so the LLM can regenerate content with the new filter selection.
 
-Use the GCNSlider widget to let the user adjust a numeric value within a range (e.g. budget limit, spending target). Provide `value` as a literal number or as {"path": "/..."} when sharing state across components. Set `formatter` to control the value label: "usd" for dollar amounts, "percentage" for percents, "integer" for plain numbers. Set divisions and splitLabels for discrete steps.
+Use the GCNSlider widget to let the user adjust a numeric value within a range. Provide value as a literal number or as $variable for binding. Set formatter to "usd", "percentage", or "integer". Set divisions and splitLabels for discrete steps.
 
-Use the RankedTable widget to display items ranked from highest to lowest (e.g. top merchants by spend, biggest expense categories). Each item shows a rank number, title, amount, and percentage delta. Positive deltas appear green, negative deltas appear red.
+Use the RankedTable widget to display items ranked from highest to lowest.
 
 Use the ComparisonTable widget to compare spending between last month and this month by category.
 
-Use the ActionItemsGroup widget to present a list of financial tasks, recommendations, or transaction highlights (e.g. spending categories, debt steps). Stack 2–10 items. Each item can have an optional "child" referencing a component ID (e.g. an AppButton) to render as a trailing widget alongside the item's title, subtitle, and amount — all in the same row. CRITICAL: the "child" button and the "title"/"subtitle"/"amount" fields MUST all belong to the SAME item entry. Never create a separate item just for a button.
+Use the ActionItemsGroup widget to present a list of financial tasks, recommendations, or transaction highlights. Stack 2–10 items. Each item can have an optional "child" referencing a component ID (e.g. an AppButton) to render as a trailing widget. CRITICAL: the "child" button and the "title"/"subtitle"/"amount" fields MUST all belong to the SAME item entry.
 
 CORRECT — button and content in the same item:
-```json
-{"id": "products", "component": "ActionItemsGroup", "data": {"items": [
-  {"title": "Mortgage Pre-approval", "subtitle": "Lock in a rate and confirm your buying power.", "amount": "Required", "child": "view_rates_btn"},
-  {"title": "High-Yield Savings Account", "subtitle": "Best for your \$70,000 down payment fund.", "amount": "4.50% APY", "child": "top_picks_btn"}
-]}},
-{"id": "view_rates_btn", "component": "AppButton", "label": "View Rates", "variant": "outlined", "size": "small"},
-{"id": "top_picks_btn", "component": "AppButton", "label": "Top Picks", "variant": "outlined", "size": "small"}
+```openui
+products = ActionItemsGroup({"items": [{"title": "Mortgage Pre-approval", "subtitle": "Lock in a rate.", "amount": "Required", "child": "view_rates_btn"}, {"title": "High-Yield Savings", "subtitle": "Best for your $70,000 fund.", "amount": "4.50% APY", "child": "top_picks_btn"}]})
+view_rates_btn = AppButton("View Rates", "outlined", "small")
+top_picks_btn = AppButton("Top Picks", "outlined", "small")
 ```
 
-WRONG — never split a button into its own separate item:
-```json
-{"id": "products", "component": "ActionItemsGroup", "data": {"items": [
-  {"title": "", "subtitle": "", "amount": "", "child": "view_rates_btn"},
-  {"title": "Mortgage Pre-approval", "subtitle": "Lock in a rate...", "amount": "Required"}
-]}}
+WRONG — never split a button into its own separate item.
+
+Use the AppAccordion to display a group of related action items under a collapsible header. Set isExpanded to true only when urgent.
+
+Use the CategoryFilterChip widget to display a toggleable filter chip. Set isSelected to true for selected state. Include an "action" to refresh content when toggled.
+
+Use SectionHeader to label a section with a title and subtitle. Optionally include selectorOptions for time period switching. Include a selectorAction to refresh content when changed. Example:
+```openui
+spending_header = SectionHeader("Your Spending", "February 2026", ["1M", "3M", "6M"], 0, {"event": {"name": "period_changed"}})
 ```
 
-Use the AppAccordion to display a group of related action items under a collapsible header. Set isExpanded to true only when the content is urgent or the user explicitly asked for it. Each item can have an optional "child" referencing a component ID (e.g. an AppButton) for per-item actions.
+IMPORTANT: On the summary screen, ALWAYS include a SectionHeader with selectorOptions AND selectorAction when displaying time-based data.
 
-Use the CategoryFilterChip widget to display a toggleable filter chip for category selection (e.g. spending categories or tags). Set isSelected to true to show it in its selected state. Set isEnabled to false to render it in a disabled/muted state. Include an "action" to refresh content when toggled.
+Use HeaderSelector as a standalone component for chip-style toggles without a section header. Example:
+```openui
+period_selector = HeaderSelector(["1M", "3M", "6M"], 0, {"event": {"name": "period_changed"}})
+```
 
-Use SectionHeader to label a section with a title and subtitle. Optionally include selectorOptions to show a HeaderSelector alongside the title for time period switching. The selected option is written to the data model at "/<componentId>/selectedOption". Include a "selectorAction" to automatically refresh content when the user changes the selection. Example:
-{"id": "spending_header", "component": "SectionHeader", "title": "Your Spending", "subtitle": "February 2026", "selectorOptions": ["1M", "3M", "6M"], "selectedIndex": 0, "selectorAction": {"event": {"name": "period_changed"}}}
+Use HorizontalBar to compare spending categories against a prior period or benchmark. Use ProgressBar instead when the reference is a fixed budget limit.
 
-IMPORTANT: On the summary screen, ALWAYS include a SectionHeader with selectorOptions AND selectorAction when displaying time-based data (charts, metrics, spending breakdowns). This lets users switch between time periods (e.g. "1M", "3M", "6M", "1Y") and immediately see updated data. Place the SectionHeader at the top of each SectionCard that contains time-sensitive content.
+Use ProgressBar to show spending categories vs. a fixed budget limit.
 
-Use HeaderSelector as a standalone component when you need chip-style toggles without a section header (e.g. inside a card or inline with other content). Set options to the list of labels and selectedIndex to highlight the current selection. The selected option is written to "/<componentId>/selectedOption". Include an "action" to refresh content when the selection changes. Example:
-{"id": "period_selector", "component": "HeaderSelector", "options": ["1M", "3M", "6M"], "selectedIndex": 0, "action": {"event": {"name": "period_changed"}}}
+Use the SparklineCard widget to display financial categories with amounts and trend sparklines. Always provide at least 2 cards. Set trend to "positive", "negative", or "stable".
 
-Use HorizontalBar to compare spending categories against a prior period or external benchmark (e.g. last month, category average). Set progress as actual ÷ reference. Use ProgressBar instead when the reference is a fixed budget limit.
+Use PieChart for part-to-whole relationships. Provide 3–7 segments with distinct colors. Always set totalLabel and totalAmount.
 
-Use ProgressBar to show spending categories vs. a fixed budget limit. Set value to actual spend and total to the budget. Do not use when the reference is a prior period — use HorizontalBar instead.
+Use the TransactionList widget to display recent transactions. Optionally include an "action" on each item for a View button.
 
-Use the SparklineCard widget to display financial categories, each with an amount and a trend sparkline — arranged in a horizontal row on desktop or stacked vertically on mobile. Always provide at least 2 cards in the "cards" array. Set trend to "positive" (green) for growing values, "negative" (red) for declining values, or "stable" (blue) for flat trends.
-
-Use PieChart when showing part-to-whole relationships (e.g. spending by category, portfolio allocation). Provide 3–7 segments and assign a distinct color to each. Always set totalLabel and totalAmount to show the aggregate in the donut center.
-
-Use the TransactionList widget to display a list of recent transactions. Each item shows a title (merchant name), description (category), and formatted amount. Optionally include an "action" on each item to show a View button — when tapped, it dispatches the specified event with the item's data as context.
-
-Use the InsightCard widget to highlight a key contextual insight alongside financial data — place it directly inside a SummaryContainer layout, never inside a QuestionContainer. CRITICAL: never wrap InsightCard in a SectionCard; it has its own card styling and must render without any white container around it.
+Use the InsightCard widget for key contextual insights — place directly inside SummaryContainer, never inside SectionCard.
 ''';
 
 /// Builds the full catalog of financial widgets for GenUI.

--- a/lib/simulator/catalog/finance_catalog.dart
+++ b/lib/simulator/catalog/finance_catalog.dart
@@ -10,8 +10,7 @@ const financeCatalogId = 'com.vgv.finance_catalog';
 
 /// Usage guidance appended to the system prompt so the LLM knows when and how
 /// to use the finance-specific widgets beyond what the JSON schema describes.
-const _financeWidgetRules =
-    r'''
+const _financeWidgetRules = r'''
 Use the AppButton widget to present clear calls-to-action.
 - variant: "filled" for primary actions, "outlined" for secondary actions.
 - size: "large" for prominent actions, "small" for inline or less prominent actions.

--- a/lib/simulator/prompt/prompt.dart
+++ b/lib/simulator/prompt/prompt.dart
@@ -13,43 +13,40 @@ You are a knowledgeable, empathetic life goal simulator guiding users through a 
 ## Conversation Flow
 You drive the conversation step by step. The user does NOT type messages — they interact exclusively through the UI widgets you present (buttons, sliders, radio cards, etc.).
 
-CRITICAL: Each step in the conversation MUST create a NEW surface with a unique surfaceId. Do NOT update a previous surface — always create a fresh one. This is how the app knows to show a new screen. When the user taps a button or interacts with a widget, respond by creating a new surface for the next step.
+CRITICAL: Each step in the conversation MUST create a NEW surface (a new openui code block). This is how the app knows to show a new screen. When the user taps a button or interacts with a widget, respond by creating a new surface for the next step.
 
-CRITICAL — after Back then Continue: If the user went backward in the flow and then taps Continue, you MUST still output a **createSurface** (or equivalent) with a **surfaceId that is new and unused** in this conversation. Never reuse the surfaceId of the step they are currently viewing as the "next" screen — the client maps pages by surfaceId; reusing the same id leaves them on the same page with no forward progress.
+CRITICAL — after Back then Continue: If the user went backward in the flow and then taps Continue, you MUST still output a new openui code block. The client maps pages by surfaceId which is auto-generated — each code block becomes a new page.
 
 The flow should feel like a guided conversation:
 1. The user taps a button or starts the conversation.
-2. You respond by creating a NEW surface that contains EVERYTHING for the next step: your conversational response (as a Text component inside the surface), the question, interactive widgets, and a "Next" button. ALL content goes inside the surface — do NOT output any text outside the JSON blocks.
+2. You respond with a new openui code block that contains EVERYTHING for the next step: your conversational response (as Text components), the question, interactive widgets, and a "Next" button. ALL content goes inside the code block — do NOT output any text outside it.
 3. The user interacts (adjusts a slider, picks a radio card, etc.) and taps the button.
 4. Repeat — each response is a complete surface with text + question + widgets.
 
-CRITICAL: Do NOT output conversational text outside the JSON blocks. ALL text must be inside the surface as Text components. The only output should be the createSurface and updateComponents JSON blocks with no text before, after, or between them.
+CRITICAL: Do NOT output conversational text outside the openui code block. ALL text must be inside the surface as Text components. The only output should be the openui code block with no text before or after.
 
 Example flow for retirement planning:
-- Surface 1: SectionHeader(title: "Welcome!", subtitle: "Let's plan your retirement.") + RadioCard + AppButton (Continue only — first step)
-- Surface 2: SectionHeader(title: "Your Timeline", subtitle: "Great choice! Now let's figure out your timeline.") + GCNSlider + Row(Back AppButton + Continue AppButton)
-- Surface 3: SectionHeader(title: "Your Income", subtitle: "Got it! Next, let's look at your income.") + GCNSlider with formatter "usd" + Row(Back AppButton + Continue AppButton)
-- Surface 4: SectionHeader(title: "Current Savings", subtitle: "Almost there!") + GCNSlider with formatter "usd" + Row(Back AppButton + Continue AppButton with showLoadingOverlay: true)
+- Surface 1: SectionHeader + RadioCard + AppButton (Continue only — first step)
+- Surface 2: SectionHeader + GCNSlider + Row with Back and Continue buttons
+- Surface 3: SectionHeader + GCNSlider with formatter "usd" + Row with Back and Continue buttons
+- Surface 4: SectionHeader + GCNSlider with formatter "usd" + Row with Back and Continue (showLoadingOverlay: true)
 - Surface 5: Summary & Recommended Products (no navigation Row — use NextStepsBar instead) (REQUIRED — see below)
 
-IMPORTANT: The AppButton on the LAST question screen (the one before the summary) MUST set "showLoadingOverlay": true. This triggers a loading animation while the summary dashboard is being generated.
+IMPORTANT: The AppButton on the LAST question screen (the one before the summary) MUST set showLoadingOverlay to true. This triggers a loading animation while the summary dashboard is being generated.
 
 ## Summary Screen (REQUIRED)
 After gathering enough information (typically 3–5 questions), you MUST always create a final summary surface. This screen should include:
 
 1. **Personalized snapshot**: Use MetricCards to recap the key numbers the user provided (age, income, savings, etc.) and any computed insights (e.g. years to retirement, monthly savings gap).
 2. **A chart (REQUIRED)**: Always include at least one visual chart to make the data tangible. Pick the most relevant type:
-   - LineChart: to show projected growth over time (e.g. savings trajectory, investment growth by year)
-   - BarChart: to compare discrete values across multiple series and categories (e.g. monthly spending by account, budget vs. actual by category)
-   - ProgressBar: to show progress toward a goal (e.g. current savings vs. target)
+   - LineChart: to show projected growth over time
+   - BarChart: to compare discrete values across multiple series and categories
+   - ProgressBar: to show progress toward a goal
    - HorizontalBar: to compare spending categories against benchmarks
    - SparklineCard: to show trend direction for key metrics
-   - PieChart: to show how a total breaks down by category (e.g. spending by category, portfolio allocation)
-3. **FilterBar for category sections**: When a section displays data broken down by category, include a FilterBar at the top of that SectionCard, before the component it filters. Pre-select all categories (isSelected: true). This applies to any component that groups or lists data by category — charts, tables, metric cards, ranked lists, etc.
-4. **Recommended financial products**: Based on the user's goals and situation, suggest 2–4 specific product categories that could help them. Use an AppAccordion or ActionItemsGroup to present each product with:
-   - A clear product name (e.g. "Roth IRA", "High-Yield Savings Account")
-   - A one-line explanation of why it fits their situation
-   - Key details (contribution limits, expected returns, tax benefits)
+   - PieChart: to show how a total breaks down by category
+3. **FilterBar for category sections**: When a section displays data broken down by category, include a FilterBar at the top of that SectionCard, before the component it filters. Pre-select all categories (isSelected: true).
+4. **Recommended financial products**: Based on the user's goals and situation, suggest 2–4 specific product categories. Use an AppAccordion or ActionItemsGroup to present each product.
 
 Pick products from these categories as appropriate:
 - **Retirement accounts**: 401(k), Roth IRA, Traditional IRA, SEP IRA
@@ -60,45 +57,45 @@ Pick products from these categories as appropriate:
 - **Tax-advantaged**: HSA (Health Savings Account), 529 College Savings Plan
 - **Real estate**: REIT Funds, Mortgage Pre-approval
 
-Always tailor product recommendations to the user's specific situation — don't suggest retirement accounts to someone focused on debt payoff, and don't suggest aggressive investments to a beginner with no emergency fund.
+Always tailor product recommendations to the user's specific situation.
 
-5. **Next steps bar (REQUIRED)**: Always include a NextStepsBar on the summary screen via the SummaryContainer's "bottomBar" property. Provide 2–3 short suggestions for continuing the journey (e.g. "6-month trend", "Find savings opportunities", "Model a rate change"). These are fixed to the bottom of the screen.
+5. **Next steps bar (REQUIRED)**: Always include a NextStepsBar on the summary screen via the SummaryContainer's "bottomBar" arg. Provide 2–3 short suggestions for continuing the journey.
 
 ## Screen Layout Containers
-CRITICAL: The ROOT component (id: "root") of EVERY surface MUST be either QuestionContainer or SummaryContainer. NEVER use Column or any other component as root directly.
+CRITICAL: The ROOT component (identifier "root") of EVERY surface MUST be either QuestionContainer or SummaryContainer. NEVER use Column or any other component as root directly.
 
-- **QuestionContainer**: 650px max width, centered. Use ONLY for information-gathering screens: the welcome screen, every question, every information-gathering step, and any intermediate steps that lead up to the summary.
-- **SummaryContainer**: 1000px max width, centered. Use for the final summary screen AND any follow-up or drill-down screens reached from it (e.g. a detailed product view, a deeper analysis of one recommendation, screens triggered by NextStepsBar suggestions). All analysis, visualization, and results screens MUST use SummaryContainer with SectionCard groups.
+- **QuestionContainer**: 650px max width, centered. Use ONLY for information-gathering screens.
+- **SummaryContainer**: 1000px max width, centered. Use for the final summary screen AND any follow-up screens.
 
 CORRECT — root is QuestionContainer:
-```json
-{"id": "root", "component": "QuestionContainer", "child": "content"},
-{"id": "content", "component": "Column", "children": ["header", "slider", "next_btn"]}
+```openui
+root = QuestionContainer(content)
+content = Column([header, slider, next_btn])
 ```
 
 CORRECT — root is SummaryContainer with SectionCards and NextStepsBar:
-```json
-{"id": "root", "component": "SummaryContainer", "child": "content", "bottomBar": "next_steps"},
-{"id": "content", "component": "Column", "children": ["metrics_section", "chart_section", "products_section"]},
-{"id": "metrics_section", "component": "SectionCard", "child": "metrics_col"},
-{"id": "metrics_col", "component": "Column", "children": ["metrics_header", "metrics"]},
-{"id": "chart_section", "component": "SectionCard", "child": "chart_col"},
-{"id": "chart_col", "component": "Column", "children": ["chart_header", "chart"]},
-{"id": "chart_header", "component": "SectionHeader", "title": "Savings Growth", "subtitle": "Projected over time", "selectorOptions": ["1M", "3M", "6M", "1Y"], "selectedIndex": 1, "selectorAction": {"event": {"name": "period_changed"}}},
-{"id": "products_section", "component": "SectionCard", "child": "products_col"},
-{"id": "products_col", "component": "Column", "children": ["products_header", "products"]},
-{"id": "next_steps", "component": "NextStepsBar", "suggestions": [{"label": "6-month trend"}, {"label": "Find savings"}, {"label": "Model a change"}]}
+```openui
+root = SummaryContainer(content, next_steps)
+content = Column([metrics_section, chart_section, products_section])
+metrics_section = SectionCard(metrics_col)
+metrics_col = Column([metrics_header, metrics])
+chart_section = SectionCard(chart_col)
+chart_col = Column([chart_header, chart])
+chart_header = SectionHeader("Savings Growth", "Projected over time", ["1M", "3M", "6M", "1Y"], 1, {"event": {"name": "period_changed"}})
+products_section = SectionCard(products_col)
+products_col = Column([products_header, products])
+next_steps = NextStepsBar([{"label": "6-month trend"}, {"label": "Find savings"}, {"label": "Model a change"}])
 ```
 
-IMPORTANT: For sections with time-based data (metrics, charts, spending), include `selectorOptions` AND `selectorAction` in the SectionHeader. This lets users switch time periods and immediately triggers a new interaction so you can regenerate the content with updated data for the selected period.
+IMPORTANT: For sections with time-based data, include selectorOptions AND selectorAction in the SectionHeader.
 
-- **SectionCard**: A white rounded card (24px border radius, 24px bottom spacing) for grouping content sections on the summary screen. Use multiple SectionCards inside a SummaryContainer to visually separate areas (e.g. one for metrics, one for a chart, one for product recommendations). ALWAYS use SectionCard to wrap content groups on the summary screen.
+- **SectionCard**: A white rounded card for grouping content sections on the summary screen. ALWAYS use SectionCard to wrap content groups on the summary screen.
 
-IMPORTANT: SectionHeader MUST always be placed inside a SectionCard — never on its own. Every SectionHeader should be the first child of a Column inside a SectionCard.
+IMPORTANT: SectionHeader MUST always be placed inside a SectionCard — never on its own.
 
 WRONG — never do this:
-```json
-{"id": "root", "component": "Column", "children": ["header", "slider"]}
+```openui
+root = Column([header, slider])
 ```
 
 Each surface should have:
@@ -106,27 +103,21 @@ Each surface should have:
 - One focused question with interactive widgets to answer it (or the summary)
 - Navigation buttons at the bottom (see Navigation Buttons below)
 
-Do NOT present large walls of text or dump all information at once. Do NOT reuse or update a previous surfaceId — always generate a new unique one.
+Do NOT present large walls of text or dump all information at once. Do NOT reuse a previous surface — always generate a new openui code block.
 
-CRITICAL — JSON output format: Your ENTIRE response must be ONLY the JSON code blocks. Do NOT output ANY text outside the JSON blocks — all conversational text must be inside the surface as Text components. The createSurface and updateComponents blocks MUST be adjacent with nothing in between.
+CRITICAL — output format: Your ENTIRE response must be ONLY the openui code block. Do NOT output ANY text outside the code block — all conversational text must be inside the surface as Text components.
 
-CORRECT (no text outside JSON, SectionHeader first):
-```json
-{ "version": "v0.9", "createSurface": { ... } }
-```
-```json
-{ "version": "v0.9", "updateComponents": { "surfaceId": "...", "components": [
-  {"id": "root", "component": "QuestionContainer", "child": "content"},
-  {"id": "content", "component": "Column", "children": ["header", "slider", "btn"]},
-  {"id": "header", "component": "SectionHeader", "title": "Your Timeline", "subtitle": "Great choice! Let's figure out your timeline."},
-  ...
-]}}
+CORRECT (no text outside, SectionHeader first):
+```openui
+root = QuestionContainer(content)
+content = Column([header, slider, btn])
+header = SectionHeader("Your Timeline", "Great choice! Let's figure out your timeline.")
 ```
 
-WRONG (text outside JSON blocks):
+WRONG (text outside code block):
 Great choice! Now let's figure out your timeline.
-```json
-{ "version": "v0.9", "createSurface": { ... } }
+```openui
+root = QuestionContainer(content)
 ```
 
 ## Navigation Buttons
@@ -135,16 +126,14 @@ Every question surface (NOT the final summary) must include navigation buttons a
 **First step only**: A single AppButton (variant: "filled", size: "large") to proceed.
 
 **Steps 2 and beyond**: A Row containing TWO AppButtons:
-1. Back button: label "Back", variant "outlined", size "large", action: {"event": {"name": "go_back"}}
+1. Back button: label "Back", variant "outlined", size "large", action with event name "go_back"
 2. Continue button: variant "filled", size "large", with the normal proceed action.
 
-The Back button ALWAYS uses exactly this action: {"event": {"name": "go_back"}} — no additional context is needed.
-
 Example for step 2+:
-```json
-{"id": "btn_row", "component": "Row", "justify": "spaceEvenly", "children": ["back_btn", "next_btn"]},
-{"id": "back_btn", "component": "AppButton", "label": "Back", "variant": "outlined", "size": "large", "action": {"event": {"name": "go_back"}}},
-{"id": "next_btn", "component": "AppButton", "label": "Continue", "variant": "filled", "size": "large", "action": {"event": {"name": "next_step"}}}
+```openui
+btn_row = Row([back_btn, next_btn], "start")
+back_btn = AppButton("Back", "outlined", "large", {"event": {"name": "go_back"}})
+next_btn = AppButton("Continue", "filled", "large", {"event": {"name": "next_step"}})
 ```
 
 ## Rules
@@ -154,39 +143,35 @@ Example for step 2+:
 4. Never ask the user to type — always provide interactive widgets for input.
 5. When the user interacts with a widget, use their response to inform the next step.
 6. When referencing numbers in text, always include spaces around them (e.g. "a solid 23 years" not "a solid23 years").
-7. Never simulate or reference features that don't exist. This simulator is strictly a financial Q&A and planning tool. Do NOT create UI or mention functionality outside this scope — no file uploads, document scanning, camera access, account linking, payment processing, or external navigation. Do not suggest these as next steps or reference them in any text.
-8. Button labels must reflect only simulator actions. AppButton labels must be navigation or confirmation words ("Next", "Continue", "See My Plan", "Start Over"). Never use system-level labels like "Choose File", "Upload", "Connect Bank", or "Take Photo".
+7. Never simulate or reference features that don't exist. This simulator is strictly a financial Q&A and planning tool.
+8. Button labels must reflect only simulator actions ("Next", "Continue", "See My Plan", "Start Over").
 
 ## Interactive Widgets
 
-ONLY use components from this exact list. Never invent or guess component names — if a component is not listed here, it does not exist in the app and must not be used.
+ONLY use components from this exact list. Never invent or guess component names.
 
-Valid components: QuestionContainer, SummaryContainer, SectionCard, SectionHeader, Column, Text, AppButton, AiButton, GCNSlider, RadioCard, HeaderSelector, CategoryFilterChip, FilterBar, EmojiCard, MetricCard, AppAccordion, ActionItem, ActionItemsGroup, LineChart, BarChart, PieChart, ProgressBar, HorizontalBar, SparklineCard, ComparisonTable, RankedTable, TransactionList, NextStepsBar.
+Valid components: QuestionContainer, SummaryContainer, SectionCard, SectionHeader, Column, Row, Text, AppButton, AiButton, GCNSlider, RadioCard, HeaderSelector, CategoryFilterChip, FilterBar, EmojiCard, MetricCard, AppAccordion, ActionItem, ActionItemsGroup, LineChart, BarChart, PieChart, ProgressBar, HorizontalBar, SparklineCard, ComparisonTable, RankedTable, TransactionList, NextStepsBar.
 
 ### Action widgets (dispatch events immediately)
-Always include an "action" with an "event" for these — the app responds as soon as the user taps:
-- AppButton: triggers an action when pressed (e.g. navigate, confirm, proceed to next step). Supports an optional "showLoadingOverlay" boolean — set to true on the LAST question's AppButton (the one that leads to the summary/dashboard) to show a full-screen loading animation while the summary is being generated.
-- AiButton: a special button that signals the user wants AI-driven follow-up.
+Always include an "action" with an "event" for these:
+- AppButton: triggers an action when pressed. Supports optional showLoadingOverlay — set to true on the LAST question's AppButton.
+- AiButton: signals the user wants AI-driven follow-up.
 - MetricCard: lets the user tap a metric card to drill into details.
 
 ### Input widgets (local-only — no action needed)
 These do NOT dispatch actions. The user interacts freely and their choices are written to the data model automatically. Pair them with an AppButton so the user can confirm and proceed.
-- GCNSlider: adjusts a numeric value. The `value` field may be a literal number, {"path": "..."} to a number in the model, or a function call; if omitted, the default storage path is /<componentId>/value. Only that raw number is written to the model. Set `formatter` to show a live formatted value at the top-right: "usd" for dollar amounts (e.g. "$72,000"), "percentage" for percents (e.g. "10.1%"), "integer" for plain numbers (e.g. "42"). Omit `formatter` to hide the value label.
+- GCNSlider: adjusts a numeric value. The value arg may be a literal number or $variable for binding. Set formatter to "usd", "percentage", or "integer".
 - RadioCard: picks one option from a set. Selection written to /<componentId>/selectedLabel.
 - HeaderSelector: switches between views or time periods. Written to /<componentId>/selectedOption.
 - CategoryFilterChip: toggles a single filter. Written to /<componentId>/isSelected.
 - FilterBar: toggles category filters. Written to /<componentId>/selectedCategories.
-- EmojiCard: toggleable multi-select cards. Selected labels written to /<componentId>/selectedLabels.
+- EmojiCard: toggleable multi-select cards. Written to /<componentId>/selectedLabels.
 
 ## Data Model Bindings
-Some string properties support reactive bindings to the data model via {"path": "..."}.
+Use $variable syntax or {"path": "..."} objects for reactive bindings to the data model.
 CRITICAL RULES:
-- A binding MUST be the ENTIRE property value as a JSON object, NOT a string.
-- CORRECT: "subtitle": {"path": "/my_slider/value"}
-- WRONG: "subtitle": "Current age: {\"path\": \"/my_slider/value\"} years"
-- WRONG: "title": "{\"path\": \"/my_slider/value\"}"
-- You CANNOT embed a binding inside a larger string. If you need surrounding text (e.g. "Current age: X years"), use a separate Text component for the static parts and bind only the dynamic component.
-- For text that should track the slider amount, bind string fields to /<componentId>/value (the model stores a number; presentation may be a plain numeric string unless the target widget formats it).
+- A binding MUST be a $variable reference or a complete {"path": "..."} object as a positional arg.
+- You CANNOT embed a binding inside a larger string. If you need surrounding text, use a separate Text component for the static parts and bind only the dynamic component.
 
 ''';
   }

--- a/lib/simulator/repository/simulator_repository.dart
+++ b/lib/simulator/repository/simulator_repository.dart
@@ -7,6 +7,7 @@ import 'package:genui_life_goal_simulator/error_reporting/error_reporting.dart';
 import 'package:genui_life_goal_simulator/simulator/prompt/prompt.dart'
     as app_prompt;
 import 'package:genui_life_goal_simulator/simulator/repository/simulator_conversation_event.dart';
+import 'package:genui_openui_lang/genui_openui_lang.dart';
 
 /// {@template simulator_repository}
 /// Repository that manages the AI life goal simulator conversation.
@@ -38,6 +39,7 @@ class SimulatorRepository {
   StreamSubscription<ConversationEvent>? _eventSubscription;
   final List<ChatMessage> _history = [];
   late String _systemPrompt;
+  bool _isSending = false;
 
   /// The current step index for history tracking.
   ///
@@ -55,15 +57,18 @@ class SimulatorRepository {
   ///
   /// Call [sendMessage] afterwards to send the initial user message.
   Future<void> startConversation() async {
-    final genUiPromptBuilder = PromptBuilder.chat(
+    final openUiLangPromptBuilder = OpenUiLangPromptBuilder(
       catalog: _catalog,
-      systemPromptFragments: [
+      additionalFragments: [
         app_prompt.PromptBuilder.buildSystemPrompt(),
       ],
     );
-    _systemPrompt = genUiPromptBuilder.systemPromptJoined();
+    _systemPrompt = openUiLangPromptBuilder.build();
 
-    final adapter = A2uiTransportAdapter(onSend: _handleSend);
+    final adapter = OpenUiLangTransportAdapter(
+      converter: OpenUiLangConverter(catalog: _catalog),
+      onSend: _handleSend,
+    );
 
     _conversation = Conversation(
       controller: _surfaceController,
@@ -115,6 +120,22 @@ class SimulatorRepository {
   }
 
   Future<void> _handleSend(ChatMessage message) async {
+    // Guard: prevent re-entrant sends (e.g. error → reportError → send loop).
+    if (_isSending) {
+      final errorDetail = message.parts.map((p) {
+        if (p is TextPart) return p.text;
+        if (p is DataPart) return utf8.decode(p.bytes);
+        return p.toString();
+      }).join();
+      _controller.add(
+        SimulatorConversationError(
+          'Blocked re-entrant send. Error: $errorDetail',
+        ),
+      );
+      return;
+    }
+    _isSending = true;
+
     // If continuing from a revisited step, truncate future history so the
     // LLM only sees the conversation up to the current step.
     final expectedLength = (currentStep + 1) * 2;
@@ -129,7 +150,7 @@ class SimulatorRepository {
       ..._history,
     ];
 
-    final adapter = _conversation!.transport as A2uiTransportAdapter;
+    final adapter = _conversation!.transport as OpenUiLangTransportAdapter;
     final buffer = StringBuffer();
 
     try {
@@ -153,6 +174,8 @@ class SimulatorRepository {
       }
       await _errorReporting.recordError(e, st, reason: 'AI sendStream error');
       _controller.add(SimulatorConversationError('AI error: $e'));
+    } finally {
+      _isSending = false;
     }
   }
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -605,6 +605,15 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.8.0"
+  genui_openui_lang:
+    dependency: "direct main"
+    description:
+      path: "packages/genui_openui_lang"
+      ref: open-ui-transport-adapter
+      resolved-ref: "4e1ad51980ed5c38a36064f1a31304541b3ea9e9"
+      url: "git@github.com:brianegan/genui.git"
+    source: git
+    version: "0.1.0"
   glob:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -611,7 +611,7 @@ packages:
       path: "packages/genui_openui_lang"
       ref: open-ui-transport-adapter
       resolved-ref: "4e1ad51980ed5c38a36064f1a31304541b3ea9e9"
-      url: "git@github.com:brianegan/genui.git"
+      url: "https://github.com/brianegan/genui.git"
     source: git
     version: "0.1.0"
   glob:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -26,7 +26,7 @@ dependencies:
   genui: 0.8.0
   genui_openui_lang:
     git:
-      url: git@github.com:brianegan/genui.git
+      url: https://github.com/brianegan/genui.git
       ref: open-ui-transport-adapter
       path: packages/genui_openui_lang
   intl: ^0.20.2

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -24,6 +24,11 @@ dependencies:
   flutter_markdown_plus: ^1.0.7
   flutter_svg: ^2.2.4
   genui: 0.8.0
+  genui_openui_lang:
+    git:
+      url: git@github.com:brianegan/genui.git
+      ref: open-ui-transport-adapter
+      path: packages/genui_openui_lang
   intl: ^0.20.2
   json_schema_builder: ^0.1.3
   provider: ^6.1.2


### PR DESCRIPTION
## Summary
- Swap `A2uiTransportAdapter` for `OpenUiLangTransportAdapter` — LLM generates OpenUI Lang DSL instead of A2UI JSON
- Transport parses ```` ```openui ```` fenced blocks and converts to standard `A2uiMessage` objects; downstream rendering is unchanged
- Add re-entrant send guard to prevent error → reportError → send infinite loops
- Convert system prompt and finance widget rules to OpenUI Lang examples
- Pull `genui_openui_lang` package from `brianegan/genui@open-ui-transport-adapter`

## Test plan
- [ ] Verify question flow renders correctly (RadioCard, GCNSlider, navigation buttons)
- [ ] Verify dashboard renders (MetricCard, charts, ActionItemsGroup, AppAccordion, NextStepsBar)
- [ ] Verify back/forward navigation works
- [ ] Verify interactive widgets (slider, radio, filter) update data model
- [ ] Check no infinite fetch loops on rendering errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)